### PR TITLE
fix: custom icons not rendering with <CssInterop.xx />

### DIFF
--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -65,6 +65,18 @@ export const ToastDemo: React.FC = () => {
         title="Custom id"
         onPress={() => toast('Custom id', { id: '123' })}
       />
+      <Button
+        title="Custom icon"
+        onPress={() => {
+          toast('Custom icon', {
+            icon: (
+              <View>
+                <Text>🚀</Text>
+              </View>
+            ),
+          });
+        }}
+      />
       <Button title="Show outside of a React component" onPress={handleToast} />
       <Button
         title="Toast with a promise"

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -240,7 +240,9 @@ export const Toast: React.FC<ToastProps> = ({
             ) : (
               <ActivityIndicator />
             )
-          ) : icon || variant in icons ? (
+          ) : icon ? (
+            <View>{icon}</View>
+          ) : variant in icons ? (
             icons[variant]
           ) : (
             <ToastIcon variant={variant} invert={invert} />


### PR DESCRIPTION
Icons weren't rendering but wrapping them with a <View> solves that. 
When I log out the icon prop it gets prefixed with <CssInterop.XX /> which is kinda strange. 