### PR TITLE
feat: more accurately represent Sonner's way of styling via the Toaster

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,7 +23,11 @@ const App: React.FC = () => {
             error: <Text>💥</Text>,
             loading: <Text>🔄</Text>,
           }}
-          toastOptions={{}}
+          toastOptions={{
+            actionButtonStyle: {
+              paddingHorizontal: 20,
+            },
+          }}
           pauseWhenPageIsHidden
         />
       </GestureHandlerRootView>

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -46,13 +46,26 @@ export const Toast: React.FC<ToastProps> = ({
     duration: durationCtx,
     addToast,
     closeButton: closeButtonCtx,
-    unstyled: unstyledCtx,
-    styles: stylesCtx,
-    classNames: classNamesCtx,
     icons,
     pauseWhenPageIsHidden,
     cn,
     invert: invertCtx,
+    toastOptions: {
+      unstyled: unstyledCtx,
+      toastContainerStyle: toastContainerStyleCtx,
+      classNames: classNamesCtx,
+      actionButtonStyle: actionButtonStyleCtx,
+      actionButtonTextStyle: actionButtonTextStyleCtx,
+      cancelButtonStyle: cancelButtonStyleCtx,
+      cancelButtonTextStyle: cancelButtonTextStyleCtx,
+      style: toastStyleCtx,
+      toastContentStyle: toastContentStyleCtx,
+      titleStyle: titleStyleCtx,
+      descriptionStyle: descriptionStyleCtx,
+      buttonsStyle: buttonsStyleCtx,
+      closeButtonStyle: closeButtonStyleCtx,
+      closeButtonIconStyle: closeButtonIconStyleCtx,
+    },
   } = useToastContext();
   const invert = invertProps ?? invertCtx;
 
@@ -194,16 +207,16 @@ export const Toast: React.FC<ToastProps> = ({
         }
       }}
       enabled={!promiseOptions && dismissible}
-      style={[stylesCtx.toastContainer, styles?.toastContainer]}
-      className={cn(classNamesCtx.toastContainer, classNames?.toastContainer)}
+      style={[toastContainerStyleCtx, styles?.toastContainer]}
+      className={cn(classNamesCtx?.toastContainer, classNames?.toastContainer)}
       unstyled={unstyled}
       important={important}
     >
       <Animated.View
-        className={cn(className, classNamesCtx.toast, classNames?.toast)}
+        className={cn(className, classNamesCtx?.toast, classNames?.toast)}
         style={[
           unstyled ? undefined : elevationStyle,
-          stylesCtx.toast,
+          toastStyleCtx,
           styles?.toast,
           style,
           unstyled
@@ -229,10 +242,10 @@ export const Toast: React.FC<ToastProps> = ({
                   gap: 16,
                   alignItems: description?.length === 0 ? 'center' : undefined,
                 },
-            stylesCtx.toastContent,
+            toastContentStyleCtx,
             styles?.toastContent,
           ]}
-          className={cn(classNamesCtx.toastContent, classNames?.toastContent)}
+          className={cn(classNamesCtx?.toastContent, classNames?.toastContent)}
         >
           {promiseOptions || variant === 'loading' ? (
             'loading' in icons ? (
@@ -257,10 +270,10 @@ export const Toast: React.FC<ToastProps> = ({
                       lineHeight: 20,
                       color: colors['text-primary'],
                     },
-                stylesCtx.title,
+                titleStyleCtx,
                 styles?.title,
               ]}
-              className={cn(classNamesCtx.title, classNames?.title)}
+              className={cn(classNamesCtx?.title, classNames?.title)}
             >
               {title}
             </Text>
@@ -275,11 +288,11 @@ export const Toast: React.FC<ToastProps> = ({
                         marginTop: 2,
                         color: colors['text-tertiary'],
                       },
-                  stylesCtx.description,
+                  descriptionStyleCtx,
                   styles?.description,
                 ]}
                 className={cn(
-                  classNamesCtx.description,
+                  classNamesCtx?.description,
                   classNames?.description
                 )}
               >
@@ -296,10 +309,10 @@ export const Toast: React.FC<ToastProps> = ({
                       gap: 16,
                       marginTop: 16,
                     },
-                stylesCtx.buttons,
+                buttonsStyleCtx,
                 styles?.buttons,
               ]}
-              className={cn(classNamesCtx.buttons, classNames?.buttons)}
+              className={cn(classNamesCtx?.buttons, classNames?.buttons)}
             >
               {isToastAction(action) ? (
                 <Pressable
@@ -319,6 +332,7 @@ export const Toast: React.FC<ToastProps> = ({
                           borderCurve: 'continuous',
                           backgroundColor: colors['background-secondary'],
                         },
+                    actionButtonStyleCtx,
                     actionButtonStyle,
                   ]}
                 >
@@ -334,6 +348,7 @@ export const Toast: React.FC<ToastProps> = ({
                             alignSelf: 'flex-start',
                             color: colors['text-primary'],
                           },
+                      actionButtonTextStyleCtx,
                       actionButtonTextStyle,
                     ]}
                     className={actionButtonTextClassName}
@@ -357,6 +372,7 @@ export const Toast: React.FC<ToastProps> = ({
                       : {
                           flexGrow: 0,
                         },
+                    cancelButtonStyleCtx,
                     cancelButtonStyle,
                   ]}
                 >
@@ -372,6 +388,7 @@ export const Toast: React.FC<ToastProps> = ({
                             alignSelf: 'flex-start',
                             color: colors['text-secondary'],
                           },
+                      cancelButtonTextStyleCtx,
                       cancelButtonTextStyle,
                     ]}
                     className={cancelButtonTextClassName}
@@ -388,15 +405,18 @@ export const Toast: React.FC<ToastProps> = ({
             <Pressable
               onPress={() => onDismiss?.(id)}
               hitSlop={10}
-              style={[stylesCtx.closeButton, styles?.closeButton]}
-              className={cn(classNamesCtx.closeButton, classNames?.closeButton)}
+              style={[closeButtonStyleCtx, styles?.closeButton]}
+              className={cn(
+                classNamesCtx?.closeButton,
+                classNames?.closeButton
+              )}
             >
               <X
                 size={20}
                 color={colors['text-secondary']}
-                style={[stylesCtx.closeButtonIcon, styles?.closeButtonIcon]}
+                style={[closeButtonIconStyleCtx, styles?.closeButtonIcon]}
                 className={cn(
-                  classNamesCtx.closeButtonIcon,
+                  classNamesCtx?.closeButtonIcon,
                   classNames?.closeButtonIcon
                 )}
               />

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -44,11 +44,8 @@ export const ToasterUI: React.FC<ToasterProps> = ({
   visibleToasts = toastDefaultValues.visibleToasts,
   swipToDismissDirection = toastDefaultValues.swipeToDismissDirection,
   closeButton,
-  style,
-  className,
-  unstyled,
   invert,
-  toastOptions,
+  toastOptions = {},
   icons,
   pauseWhenPageIsHidden,
   cn,
@@ -155,6 +152,8 @@ export const ToasterUI: React.FC<ToasterProps> = ({
     [dismissToast]
   );
 
+  const { style, className, unstyled } = toastOptions;
+
   const value = React.useMemo<ToasterContextType>(
     () => ({
       duration: duration ?? toastDefaultValues.duration,
@@ -166,14 +165,13 @@ export const ToasterUI: React.FC<ToasterProps> = ({
       unstyled: unstyled ?? toastDefaultValues.unstyled,
       addToast: addToastHandler,
       invert: invert ?? toastDefaultValues.invert,
-      styles: toastOptions?.styles ?? {},
-      classNames: toastOptions?.classNames ?? {},
       icons: icons ?? {},
       pauseWhenPageIsHidden:
         pauseWhenPageIsHidden ?? toastDefaultValues.pauseWhenPageIsHidden,
       cn: cn ?? toastDefaultValues.cn,
       gap: gap ?? toastDefaultValues.gap,
       theme: theme ?? toastDefaultValues.theme,
+      toastOptions,
     }),
     [
       duration,

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ type ExternalToast = Omit<
   id?: string | number;
 };
 
-export type ToasterProps = StyleProps & {
+export type ToasterProps = {
   duration?: number;
   theme?: ToastTheme;
   // richColors?: boolean; (false)
@@ -96,10 +96,29 @@ export type ToasterProps = StyleProps & {
   position?: ToastPosition;
   closeButton?: boolean;
   offset?: number;
+  style?: ViewStyle;
+  className?: string;
   // dir?: 'ltr' | 'rtl'; (ltr)
   // hotkey?: string; // hotkeys not supported on mobile
   invert?: boolean;
-  toastOptions?: StyleProps;
+  toastOptions?: {
+    actionButtonStyle?: ViewStyle;
+    actionButtonTextStyle?: TextStyle;
+    cancelButtonStyle?: ViewStyle;
+    cancelButtonTextStyle?: TextStyle;
+    className?: string;
+    titleStyle?: TextStyle;
+    descriptionStyle?: TextStyle;
+    style?: ViewStyle;
+    unstyled?: boolean;
+
+    toastContainerStyle?: ViewStyle;
+    toastContentStyle?: ViewStyle;
+    buttonsStyle?: ViewStyle;
+    closeButtonStyle?: ViewStyle;
+    closeButtonIconStyle?: ViewStyle;
+    classNames?: StyleProps['classNames'];
+  };
   gap?: number;
   loadingIcon?: React.ReactNode;
   // pauseWhenPageIsHidden?: boolean; (false)
@@ -127,16 +146,14 @@ export type ToasterContextType = Required<
     | 'swipToDismissDirection'
     | 'closeButton'
     | 'position'
-    | 'unstyled'
     | 'invert'
-    | 'styles'
-    | 'classNames'
     | 'icons'
     | 'offset'
     | 'pauseWhenPageIsHidden'
     | 'cn'
     | 'gap'
     | 'theme'
+    | 'toastOptions'
   >
 > & {
   addToast: AddToastContextHandler;


### PR DESCRIPTION
## Summary

Turns out that I was misunderstanding the props passed to Toaster. 
I did however take a stance regarding two things mainly, duration and closeButton - they are both passable directly to Toaster and to toastOptions on Toaster in Sonner for web.