### PR TITLE
fix: await the promise to be able to catch its error and a toast

### DIFF
--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -97,13 +97,30 @@ export const ToastDemo: React.FC = () => {
       />
       <Button title="Show outside of a React component" onPress={handleToast} />
       <Button
-        title="Toast with a promise"
+        title="Toast with a successful promise"
         onPress={() => {
           toast.promise(
             new Promise((resolve) => {
               setTimeout(() => {
                 resolve('Promise resolved');
-              }, 7000);
+              }, 2000);
+            }),
+            {
+              loading: 'Loading...',
+              success: (result: string) => `Promise resolved: ${result}`,
+              error: 'Promise failed',
+            }
+          );
+        }}
+      />
+      <Button
+        title="Toast with a failed promise"
+        onPress={() => {
+          toast.promise(
+            new Promise((_, reject) => {
+              setTimeout(() => {
+                reject('Promise rejected');
+              }, 2000);
             }),
             {
               loading: 'Loading...',

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -189,44 +189,49 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
     );
 
     React.useEffect(() => {
-      if (isResolvingPromise.current) {
-        return;
-      }
-
-      if (promiseOptions?.promise) {
-        try {
-          isResolvingPromise.current = true;
-          promiseOptions.promise.then((data) => {
-            addToast({
-              title: promiseOptions.success(data) ?? 'Success',
-              id,
-              variant: 'success',
-              promiseOptions: undefined,
-            });
-            isResolvingPromise.current = false;
-          });
-        } catch (error) {
-          addToast({
-            title: promiseOptions.error ?? 'Error',
-            id,
-            variant: 'error',
-            promiseOptions: undefined,
-          });
-          isResolvingPromise.current = false;
+      const handlePromise = async () => {
+        if (isResolvingPromise.current) {
+          return;
         }
 
-        return;
-      }
+        if (promiseOptions?.promise) {
+          isResolvingPromise.current = true;
 
-      if (duration === Infinity) {
-        return;
-      }
+          try {
+            await promiseOptions.promise.then((data) => {
+              addToast({
+                title: promiseOptions.success(data) ?? 'Success',
+                id,
+                variant: 'success',
+                promiseOptions: undefined,
+              });
+            });
+          } catch (error) {
+            addToast({
+              title: promiseOptions.error ?? 'Error',
+              id,
+              variant: 'error',
+              promiseOptions: undefined,
+            });
+          } finally {
+            isResolvingPromise.current = false;
+          }
 
-      // Start the timer only if it hasn't been started yet
-      if (!timerStart.current) {
-        timerStart.current = Date.now();
-        startTimer();
-      }
+          return;
+        }
+
+        if (duration === Infinity) {
+          return;
+        }
+
+        // Start the timer only if it hasn't been started yet
+        if (!timerStart.current) {
+          timerStart.current = Date.now();
+          startTimer();
+        }
+      };
+
+      handlePromise();
     }, [
       duration,
       id,


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

hello! this PR fixes the `toast.promise` method with a rejected promise where it is never catch as the promise was not awaited
this resulted in the toast staying in the `loading` state forever


## Test plan
`yarn example start` and test the two buttons:
- **Toast with a successful promise**
- **Toast with a failed promise**
<!-- Provide instructions or files for testing the changes, especially if special setup is required. -->