### PR TITLE
feat: add onPress

### DIFF
--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Button, Image, Pressable, ScrollView, Text, View } from 'react-native';
+import {
+  Alert,
+  Button,
+  Image,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
 import { toast } from 'sonner-native';
 
 export const ToastDemo: React.FC = () => {
@@ -402,6 +410,21 @@ export const ToastDemo: React.FC = () => {
         onPress={() => toast('Dynamic position', { position: 'bottom-center' })}
       />
       <Button title="Warning toast" onPress={() => toast.warning('Warning')} />
+      <Button
+        title="OnPress action"
+        onPress={() => {
+          const id = toast.success('OnPress action', {
+            dismissible: true,
+            onPress: () => {
+              toast.dismiss(id);
+              setToastId(null);
+              Alert.alert('press');
+            },
+          });
+
+          setToastId(id);
+        }}
+      />
     </ScrollView>
   );
 };

--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -417,7 +417,7 @@ export const ToastDemo: React.FC = () => {
         title="OnPress action"
         onPress={() => {
           const id = toast.success('OnPress action', {
-            dismissible: true,
+            dismissible: false,
             onPress: () => {
               toast.dismiss(id);
               setToastId(null);

--- a/src/gestures.tsx
+++ b/src/gestures.tsx
@@ -105,10 +105,9 @@ export const ToastSwipeHandler: React.FC<
     });
 
   const tap = Gesture.Tap().onEnd(() => {
-    if (!enabled) {
-      return;
+    if (onPress) {
+      runOnJS(onPress)();
     }
-    runOnJS(onPress)();
   });
 
   const animatedStyle = useAnimatedStyle(() => {

--- a/src/gestures.tsx
+++ b/src/gestures.tsx
@@ -25,6 +25,7 @@ type ToastSwipeHandlerProps = Pick<ToastProps, 'important'> & {
   enabled?: boolean;
   unstyled?: boolean;
   position?: ToastPosition;
+  onPress: () => void;
 };
 
 export const ToastSwipeHandler: React.FC<
@@ -40,6 +41,7 @@ export const ToastSwipeHandler: React.FC<
   unstyled,
   important,
   position: positionProps,
+  onPress,
 }) => {
   const translate = useSharedValue(0);
   const {
@@ -102,6 +104,13 @@ export const ToastSwipeHandler: React.FC<
       runOnJS(onFinalize)();
     });
 
+  const tap = Gesture.Tap().onEnd(() => {
+    if (!enabled) {
+      return;
+    }
+    runOnJS(onPress)();
+  });
+
   const animatedStyle = useAnimatedStyle(() => {
     return {
       transform: [
@@ -121,7 +130,7 @@ export const ToastSwipeHandler: React.FC<
   }, [direction, translate]);
 
   return (
-    <GestureDetector gesture={pan}>
+    <GestureDetector gesture={Gesture.Race(tap, pan)}>
       <Animated.View
         style={[
           animatedStyle,

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -14,6 +14,7 @@ import { CircleCheck, CircleX, Info, TriangleAlert, X } from './icons';
 import { isToastAction, type ToastProps, type ToastRef } from './types';
 import { useAppStateListener } from './use-app-state';
 import { useDefaultStyles } from './use-default-styles';
+import { RectButton } from 'react-native-gesture-handler';
 
 export const Toast = React.forwardRef<ToastRef, ToastProps>(
   (
@@ -49,6 +50,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       important,
       invert: invertProps,
       richColors: richColorsProps,
+      onPress,
     },
     ref
   ) => {
@@ -284,7 +286,8 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
             onDismiss?.(id);
           }
         }}
-        enabled={!promiseOptions && dismissible}
+        onPress={() => onPress?.()}
+        enabled={onPress ? true : !promiseOptions && dismissible}
         style={[toastContainerStyleCtx, styles?.toastContainer]}
         className={cn(
           classNamesCtx?.toastContainer,
@@ -423,25 +426,27 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
               </View>
             </View>
             {closeButton && dismissible ? (
-              <Pressable
-                onPress={() => onDismiss?.(id)}
-                hitSlop={10}
-                style={[closeButtonStyleCtx, styles?.closeButton]}
-                className={cn(
-                  classNamesCtx?.closeButton,
-                  classNames?.closeButton
-                )}
-              >
-                <X
-                  size={20}
-                  color={defaultStyles.closeButtonColor}
-                  style={[closeButtonIconStyleCtx, styles?.closeButtonIcon]}
+              <RectButton disallowInterruption>
+                <Pressable
+                  onPress={() => onDismiss?.(id)}
+                  hitSlop={10}
+                  style={[closeButtonStyleCtx, styles?.closeButton]}
                   className={cn(
-                    classNamesCtx?.closeButtonIcon,
-                    classNames?.closeButtonIcon
+                    classNamesCtx?.closeButton,
+                    classNames?.closeButton
                   )}
-                />
-              </Pressable>
+                >
+                  <X
+                    size={20}
+                    color={defaultStyles.closeButtonColor}
+                    style={[closeButtonIconStyleCtx, styles?.closeButtonIcon]}
+                    className={cn(
+                      classNamesCtx?.closeButtonIcon,
+                      classNames?.closeButtonIcon
+                    )}
+                  />
+                </Pressable>
+              </RectButton>
             ) : null}
           </View>
         </Animated.View>

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -289,7 +289,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
           }
         }}
         onPress={() => onPress?.()}
-        enabled={onPress ? true : !promiseOptions && dismissible}
+        enabled={!promiseOptions && dismissible}
         style={[toastContainerStyleCtx, styles?.toastContainer]}
         className={cn(
           classNamesCtx?.toastContainer,

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export type ToastProps = StyleProps & {
   cancelButtonTextStyle?: TextStyle;
   cancelButtonClassName?: string;
   cancelButtonTextClassName?: string;
+  onPress?: () => void;
 };
 
 export type ToastRef = {


### PR DESCRIPTION
add onPress props, close #96 

## Test plan

Added examples to ToastDemo. added `OnPress action` button at last.