### PR TITLE
feat: toast.promise error option can be a callback fn or a string

### DIFF
--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -128,13 +128,16 @@ export const ToastDemo: React.FC = () => {
           toast.promise(
             new Promise((_, reject) => {
               setTimeout(() => {
-                reject('Promise rejected');
+                reject(new Error('promise failed'));
               }, 2000);
             }),
             {
               loading: 'Loading...',
               success: (result: string) => `Promise resolved: ${result}`,
-              error: 'Promise failed',
+              error: (error) =>
+                error instanceof Error
+                  ? `catch 'Error' ${error.message}`
+                  : 'Promise failed',
             }
           );
         }}

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -199,17 +199,19 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
           isResolvingPromise.current = true;
 
           try {
-            await promiseOptions.promise.then((data) => {
-              addToast({
-                title: promiseOptions.success(data) ?? 'Success',
-                id,
-                variant: 'success',
-                promiseOptions: undefined,
-              });
+            const data = await promiseOptions.promise;
+            addToast({
+              title: promiseOptions.success(data) ?? 'Success',
+              id,
+              variant: 'success',
+              promiseOptions: undefined,
             });
           } catch (error) {
             addToast({
-              title: promiseOptions.error ?? 'Error',
+              title:
+                typeof promiseOptions.error === 'function'
+                  ? promiseOptions.error(error)
+                  : (promiseOptions.error ?? 'Error'),
               id,
               variant: 'error',
               promiseOptions: undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ type StyleProps = {
 type PromiseOptions = {
   promise: Promise<unknown>;
   success: (result: any) => string; // TODO: type this with generics
-  error: string;
+  error: ((error: unknown) => string) | string;
   loading: string;
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

this PR updates the `error` option in the `toast.promise` method to be either a string (current type), or a function that receives the error as its argument

```ts
toast.promise(somePromise, {
  error: (err) => { /* use err */}
})
```

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan


<!-- Provide instructions or files for testing the changes, especially if special setup is required. -->