### PR TITLE
fix: android action onclick

### DIFF
--- a/src/gestures.tsx
+++ b/src/gestures.tsx
@@ -82,6 +82,13 @@ export const ToastSwipeHandler: React.FC<
       const threshold = direction === 'left' ? -WINDOW_WIDTH * 0.25 : -16;
       const shouldDismiss = translate.value < threshold;
 
+      if (Math.abs(translate.value) < 16) {
+        translate.value = withTiming(0, {
+          easing: Easing.elastic(0.8),
+        });
+        return;
+      }
+
       if (shouldDismiss) {
         translate.value = withTiming(
           -WINDOW_WIDTH,


### PR DESCRIPTION
Closes #98 

This one was wild. There's no way of stopping the Pan gesture to execute, stopPropagation doesn't work, minDistance of the gesture didn't work, activeOffsetY/X didn't work, but this works. 