### PR TITLE
feat: added customizeable close button

### DIFF
--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -428,6 +428,16 @@ export const ToastDemo: React.FC = () => {
           setToastId(id);
         }}
       />
+
+      <Button
+        title="Custom close button"
+        onPress={() => {
+          const id = toast.success('Custom close button', {
+            close: <Button title="close" onPress={() => toast.dismiss(id)} />,
+            closeButton: undefined,
+          });
+        }}
+      />
     </ScrollView>
   );
 };

--- a/src/gestures.tsx
+++ b/src/gestures.tsx
@@ -10,8 +10,8 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
-import { easeInOutCircFn } from './easings';
 import { useToastContext } from './context';
+import { easeInOutCircFn } from './easings';
 import type { ToastPosition, ToastProps } from './types';
 
 const { width: WINDOW_WIDTH } = Dimensions.get('window');
@@ -113,7 +113,6 @@ export const ToastSwipeHandler: React.FC<
 
   const tap = Gesture.Tap().onEnd(() => {
     'worklet';
-    
     if (onPress) {
       runOnJS(onPress)();
     }

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -271,7 +271,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       if (close) {
         return close;
       }
-      if (typeof closeButton === 'boolean' && closeButton) {
+      if (closeButton) {
         return (
           <Pressable
             onPress={() => onDismiss?.(id)}

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -27,6 +27,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       variant,
       action,
       cancel,
+      close,
       onDismiss,
       onAutoClose,
       dismissible = toastDefaultValues.dismissible,
@@ -263,6 +264,52 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       variant,
     });
 
+    const renderCloseButton = React.useMemo(() => {
+      if (!dismissible) {
+        return null;
+      }
+      if (close) {
+        return close;
+      }
+      if (typeof closeButton === 'boolean' && closeButton) {
+        return (
+          <Pressable
+            onPress={() => onDismiss?.(id)}
+            hitSlop={10}
+            style={[closeButtonStyleCtx, styles?.closeButton]}
+            className={cn(classNamesCtx?.closeButton, classNames?.closeButton)}
+          >
+            <X
+              size={20}
+              color={defaultStyles.closeButtonColor}
+              style={[closeButtonIconStyleCtx, styles?.closeButtonIcon]}
+              className={cn(
+                classNamesCtx?.closeButtonIcon,
+                classNames?.closeButtonIcon
+              )}
+            />
+          </Pressable>
+        );
+      }
+      return null;
+    }, [
+      classNames?.closeButton,
+      classNames?.closeButtonIcon,
+      classNamesCtx?.closeButton,
+      classNamesCtx?.closeButtonIcon,
+      close,
+      closeButton,
+      closeButtonIconStyleCtx,
+      closeButtonStyleCtx,
+      cn,
+      defaultStyles?.closeButtonColor,
+      dismissible,
+      id,
+      onDismiss,
+      styles?.closeButton,
+      styles?.closeButtonIcon,
+    ]);
+
     if (jsx) {
       return jsx;
     }
@@ -426,27 +473,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                 )}
               </View>
             </View>
-            {closeButton && dismissible ? (
-              <Pressable
-                onPress={() => onDismiss?.(id)}
-                hitSlop={10}
-                style={[closeButtonStyleCtx, styles?.closeButton]}
-                className={cn(
-                  classNamesCtx?.closeButton,
-                  classNames?.closeButton
-                )}
-              >
-                <X
-                  size={20}
-                  color={defaultStyles.closeButtonColor}
-                  style={[closeButtonIconStyleCtx, styles?.closeButtonIcon]}
-                  className={cn(
-                    classNamesCtx?.closeButtonIcon,
-                    classNames?.closeButtonIcon
-                  )}
-                />
-              </Pressable>
-            ) : null}
+            {renderCloseButton}
           </View>
         </Animated.View>
       </ToastSwipeHandler>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import type { TextStyle, ViewStyle } from 'react-native';
 
 type StyleProps = {
@@ -54,7 +55,6 @@ export type ToastProps = StyleProps & {
   variant: ToastVariant;
   jsx?: React.ReactNode;
   description?: string;
-  closeButton?: boolean;
   invert?: boolean;
   important?: boolean;
   duration?: number;
@@ -63,6 +63,8 @@ export type ToastProps = StyleProps & {
   icon?: React.ReactNode;
   action?: ToastAction | React.ReactNode;
   cancel?: ToastAction | React.ReactNode;
+  close?: React.ReactNode;
+  closeButton?: boolean;
   richColors?: boolean;
   onDismiss?: (id: string | number) => void;
   onAutoClose?: (id: string | number) => void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Adds basic functionality for customising close button. 
Moved the rendering to a useMemo hook to make it easier to follow the logic flow, since I did not want to break existing usages of the `closeButton` prop

## Test plan
There is an example usage in the example app. Basically it tries to mimic the `action` and `cancel` actions except we only accept a ReactNode instead of a ToastAction

Fixes #129 