### PR TITLE
feat: add a ToastWrapper to wrap the toast with a custom component

### DIFF
--- a/docs/docs/Toaster.md
+++ b/docs/docs/Toaster.md
@@ -69,6 +69,29 @@ import { ZView } from 'react-native-z-view';
 />;
 ```
 
+
+### Dismiss toast on tap
+
+Use the `ToastWrapper` prop to wrap the Toast component with a custom component. This is useful when you want to customize the behavior of the toast, for example add a dismiss on tap instead of the the close icon.
+
+```tsx
+import { Pressable } from "react-native"
+
+function Wrapper({toastId, children}){
+  function onPress(){
+    toast.dismiss(toastId)
+  }
+  return <Pressable onPress={onPress}>{children}</Pressable>
+}
+
+<Toaster
+  ToastWrapper={Wrapper}
+  toastOptions={{
+    style: { backgroundColor: 'red' },
+  }}
+/>;
+```
+
 ## API Reference
 
 | Property                  |                                            Description                                             |      Default |
@@ -85,5 +108,6 @@ import { ZView } from 'react-native-z-view';
 | pauseWhenPageIsHidden     |                        Pauses toast timers when the app enters background.                         |         `{}` |
 | `swipeToDismissDirection` |                             Swipe direction to dismiss (`left`, `up`).                             |         `up` |
 | ToasterOverlayWrapper     |                                Custom component to wrap the Toaster.                               |        `div` |
+| ToastWrapper              |                                Custom component to wrap the Toast.                                 |        `div` |
 | autoWiggleOnUpdate        |             Adds a wiggle animation on toast update. `never`, `toast-change`, `always`             |      `never` |
 | richColors                |                             Makes error and success state more colorful                            |      `false` |

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,10 +1,25 @@
 import * as React from 'react';
-import { Text } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { Toaster } from 'sonner-native';
+import { toast, Toaster } from 'sonner-native';
 import '../global.css';
 import Navigator from './navigation';
+
+const ToastWrapper: React.ComponentType<
+  React.ComponentProps<typeof View> & {
+    children: React.ReactNode;
+    toastId: string | number;
+  }
+> = ({ toastId, style, ...props }) => {
+  return (
+    <Pressable
+      style={[style, { backgroundColor: 'red' }]}
+      onPress={() => toast.dismiss(toastId)}
+      {...props}
+    />
+  );
+};
 
 const App: React.FC = () => {
   return (
@@ -29,6 +44,7 @@ const App: React.FC = () => {
               paddingHorizontal: 20,
             },
           }}
+          ToastWrapper={ToastWrapper}
           pauseWhenPageIsHidden
         />
       </GestureHandlerRootView>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,25 +1,11 @@
 import * as React from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Text } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { toast, Toaster } from 'sonner-native';
+import { Toaster } from 'sonner-native';
 import '../global.css';
 import Navigator from './navigation';
-
-const ToastWrapper: React.ComponentType<
-  React.ComponentProps<typeof View> & {
-    children: React.ReactNode;
-    toastId: string | number;
-  }
-> = ({ toastId, style, ...props }) => {
-  return (
-    <Pressable
-      style={[style, { backgroundColor: 'red' }]}
-      onPress={() => toast.dismiss(toastId)}
-      {...props}
-    />
-  );
-};
+// import { ToastWrapper } from './ToastWrapper';
 
 const App: React.FC = () => {
   return (
@@ -44,7 +30,7 @@ const App: React.FC = () => {
               paddingHorizontal: 20,
             },
           }}
-          ToastWrapper={ToastWrapper}
+          // ToastWrapper={ToastWrapper}
           pauseWhenPageIsHidden
         />
       </GestureHandlerRootView>

--- a/example/src/ToastWrapper.tsx
+++ b/example/src/ToastWrapper.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Pressable, View } from 'react-native';
+import { toast } from 'sonner-native';
+import '../global.css';
+
+export const ToastWrapper: React.ComponentType<
+  React.ComponentProps<typeof View> & {
+    children: React.ReactNode;
+    toastId: string | number;
+  }
+> = ({ toastId, style, ...props }) => {
+  return (
+    <Pressable
+      style={[style, { backgroundColor: 'red' }]}
+      onPress={() => toast.dismiss(toastId)}
+      {...props}
+    />
+  );
+};

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -104,6 +104,7 @@ export const ToasterUI: React.FC<
   setToasts,
   toastsCounter,
   toastRefs,
+  ToastWrapper,
   ...props
 }) => {
   addToastHandler = React.useCallback(
@@ -325,6 +326,22 @@ export const ToasterUI: React.FC<
     <ToastContext.Provider value={value}>
       <Positioner position={position}>
         {positionedNonDynamicToasts.map((positionedToast) => {
+          if (ToastWrapper) {
+            return (
+              <ToastWrapper
+                key={positionedToast.id}
+                toastId={positionedToast.id}
+              >
+                <Toast
+                  {...positionedToast}
+                  onDismiss={onDismiss}
+                  onAutoClose={onAutoClose}
+                  ref={toastRefs.current[positionedToast.id]}
+                  {...props}
+                />
+              </ToastWrapper>
+            );
+          }
           return (
             <Toast
               key={positionedToast.id}
@@ -343,6 +360,22 @@ export const ToasterUI: React.FC<
         }
       >
         {positionedDynamicToasts.map((positionedToast) => {
+          if (ToastWrapper) {
+            return (
+              <ToastWrapper
+                key={positionedToast.id}
+                toastId={positionedToast.id}
+              >
+                <Toast
+                  key={positionedToast.id}
+                  {...positionedToast}
+                  onDismiss={onDismiss}
+                  onAutoClose={onAutoClose}
+                  {...props}
+                />
+              </ToastWrapper>
+            );
+          }
           return (
             <Toast
               key={positionedToast.id}

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -331,6 +331,7 @@ export const ToasterUI: React.FC<
               <ToastWrapper
                 key={positionedToast.id}
                 toastId={positionedToast.id}
+                style={{ width: '100%' }}
               >
                 <Toast
                   {...positionedToast}
@@ -365,6 +366,7 @@ export const ToasterUI: React.FC<
               <ToastWrapper
                 key={positionedToast.id}
                 toastId={positionedToast.id}
+                style={{ width: '100%' }}
               >
                 <Toast
                   key={positionedToast.id}

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,10 @@ export type ToasterProps = {
   swipeToDismissDirection?: ToastSwipeDirection;
   pauseWhenPageIsHidden?: boolean;
   ToasterOverlayWrapper?: React.ComponentType<{ children: React.ReactNode }>;
+  ToastWrapper?: React.ComponentType<{
+    children: React.ReactNode;
+    toastId: string | number;
+  }>;
 };
 
 export type AddToastContextHandler = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { TextStyle, ViewStyle } from 'react-native';
+import type { TextStyle, ViewProps, ViewStyle } from 'react-native';
 
 type StyleProps = {
   unstyled?: boolean;
@@ -125,10 +125,12 @@ export type ToasterProps = {
   swipeToDismissDirection?: ToastSwipeDirection;
   pauseWhenPageIsHidden?: boolean;
   ToasterOverlayWrapper?: React.ComponentType<{ children: React.ReactNode }>;
-  ToastWrapper?: React.ComponentType<{
-    children: React.ReactNode;
-    toastId: string | number;
-  }>;
+  ToastWrapper?: React.ComponentType<
+    ViewProps & {
+      children: React.ReactNode;
+      toastId: string | number;
+    }
+  >;
 };
 
 export type AddToastContextHandler = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

I wanted to add a way to dismiss the toast on tap and not just on the close icon.
Fixes #211 


I added the ToastWrapper in the ToasterUI component like you did for the previous Wrapper. If you prefer it inside the Toast complete let me know but i felt like it was more complicated. I also pass the toastId for convenience, let me know if you prefer to do it an other way or pass something else. but in order to dismiss the toast or target it, we need the toastId.

i rarely make Pr so let me know if i missed something or not. in the meantime will to a bunch more tests on my end in case in missed something logic wise :)

EDIT: currently looking at using a Wrapper makes the toast not expand anymore, looking into it.

it looks like you pass `{ width: '100%' },` to `ToastSwipeHandler` container, so wondering how you want us to handle this? do i pass next to toastId a `style` props to let user get the `width: 100%` or we make it part of the doc to let user know they need to pass width: 100% to the container of the Wrapper?