### PR TITLE
fix: updating toasts race condition

### DIFF
--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -119,12 +119,12 @@ export const ToastDemo: React.FC = () => {
           toast.promise(
             new Promise((resolve) => {
               setTimeout(() => {
-                resolve('Promise resolved');
+                resolve('!');
               }, 2000);
             }),
             {
               loading: 'Loading...',
-              success: (result: string) => `Promise resolved: ${result}`,
+              success: (result: string) => `Success${result}`,
               error: 'Promise failed',
             }
           );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Basically changes the setToasts() so that it always uses the parameter to the setter callback as the current state for toasts. That way we always have an up to date array of toasts before determining if we should update or create a new toast.

Closes #206 
Closes #216 
