### PR TITLE
fix: the missed style props for the toaster props

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ type ExternalToast = Omit<
   id?: string | number;
 };
 
-export type ToasterProps = {
+export type ToasterProps = Omit<StyleProps, 'style'> & {
   duration?: number;
   theme?: ToastTheme;
   // richColors?: boolean; (false)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

While the Toaster component accepts the StyleProps and is used into the Toast component (`styles` or `unstyled`) in the Toaster, they aren't type-safe

## Test plan

<!-- Provide instructions or files for testing the changes, especially if special setup is required. -->