### PR TITLE
docs:  update property theme's default value to match reality ("system")

### DIFF
--- a/docs/docs/Toaster.md
+++ b/docs/docs/Toaster.md
@@ -96,7 +96,7 @@ function Wrapper({toastId, children}){
 
 | Property                  |                                            Description                                             |      Default |
 | :------------------------ | :------------------------------------------------------------------------------------------------: | -----------: |
-| theme                     |                                          `light`, `dark`                                           |      `light` |
+| theme                     |                                          `light`, `dark`                                           |     `system` |
 | visibleToasts             |                                  Maximum number of visible toasts                                  |          `3` |
 | position                  |                              Place where the toasts will be rendered                               | `top-center` |
 | offset                    |                                   Offset from the top or bottom                                    |          `0` |


### PR DESCRIPTION
## Summary

Under API Reference in `Toaster` update property `theme`'s default value to match [reality](https://github.com/gunnartorfis/sonner-native/blob/ecc3332d6c9920d4a2f96b078aa1eed7987b5780/src/constants.ts#L38) ("system")

## Test plan

Skim  and read through textual changes in docs