### PR TITLE
feat: allow variant-specific default styles in Toaster

### DIFF
--- a/docs/docs/Toaster.md
+++ b/docs/docs/Toaster.md
@@ -52,6 +52,22 @@ You can provide default styles for all toasts by passing the `style` prop to the
 />
 ```
 
+### Styling Toasts by Variant
+
+You can provide default styles for specific toast variants within `toastOptions`. These styles will be applied as the base for any toast of that type.
+
+```tsx
+<Toaster
+  toastOptions={{
+    // Set a default style for all success toasts
+    success: {
+      backgroundColor: '#28a745',
+    },
+    // This also works for 'error', 'warning', 'info', and 'loading'
+  }}
+/>
+```
+
 ### Usage with react-native-z-view
 
 Use the `ToasterOverlayWrapper` prop to wrap the Toaster component with a custom component. This is useful when using `react-native-z-view` to render the toasts.

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -70,6 +70,11 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
         buttonsStyle: buttonsStyleCtx,
         closeButtonStyle: closeButtonStyleCtx,
         closeButtonIconStyle: closeButtonIconStyleCtx,
+        success: successStyleCtx,
+        error: errorStyleCtx,
+        warning: warningStyleCtx,
+        info: infoStyleCtx,
+        loading: loadingStyleCtx,
       },
     } = useToastContext();
     const invert = invertProps ?? invertCtx;
@@ -256,6 +261,16 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       variant,
     });
 
+    const variantStyles = {
+      success: successStyleCtx,
+      error: errorStyleCtx,
+      warning: warningStyleCtx,
+      info: infoStyleCtx,
+      loading: loadingStyleCtx,
+    };
+
+    const variantStyle = variantStyles[variant];
+
     const renderCloseButton = React.useMemo(() => {
       if (!dismissible) {
         return null;
@@ -351,6 +366,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
             unstyled ? undefined : elevationStyle,
             defaultStyles.toast,
             toastStyleCtx,
+            variantStyle,
             styles?.toast,
             style,
             wiggleAnimationStyle,

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,11 @@ export type ToasterProps = Omit<StyleProps, 'style'> & {
     buttonsStyle?: ViewStyle;
     closeButtonStyle?: ViewStyle;
     closeButtonIconStyle?: ViewStyle;
+    success?: ViewStyle;
+    error?: ViewStyle;
+    warning?: ViewStyle;
+    info?: ViewStyle;
+    loading?: ViewStyle;
   };
   gap?: number;
   loadingIcon?: React.ReactNode;


### PR DESCRIPTION
## Summary

This PR introduces the ability to set default styles for specific toast variants (success, error, warning, info, loading) directly in the <Toaster /> component via the toastOptions prop.

Fixes #270

## Test plan
This feature can be tested by running the example application and modifying the `App.tsx` file

1.  In `example/src/App.tsx`, add variant-specific styles to the `<Toaster>` component:
    ```tsx
    <Toaster
      position="top-center"
      toastOptions={{
        success: {
          backgroundColor: '#28a745', // Green
        },
        error: {
          backgroundColor: '#dc3545', // Red
        },
        warning: {
          backgroundColor: '#ffc107', // Yellow
        },
      }}
    />
    ```
2.  Run the example app (`yarn example start`)
3.  Trigger different toast variants using the buttons in the demo
4.  Verify that each toast appears with its corresponding default background color. 