### PR TITLE
feat: make toast text width adapt by allowing

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -65,6 +65,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
         cancelButtonTextStyle: cancelButtonTextStyleCtx,
         style: toastStyleCtx,
         toastContentStyle: toastContentStyleCtx,
+        contentWrapperStyle: contentWrapperStyleCtx,
         titleStyle: titleStyleCtx,
         descriptionStyle: descriptionStyleCtx,
         buttonsStyle: buttonsStyleCtx,
@@ -382,7 +383,13 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                 richColors={richColors}
               />
             )}
-            <View style={{ flex: 1 }}>
+            <View
+              style={[
+                defaultStyles.contentWrapper,
+                contentWrapperStyleCtx,
+                styles?.contentWrapper,
+              ]}
+            >
               <Text style={[defaultStyles.title, titleStyleCtx, styles?.title]}>
                 {title}
               </Text>

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ type StyleProps = {
     toastContainer?: ViewStyle;
     toast?: ViewStyle;
     toastContent?: ViewStyle;
+    contentWrapper?: ViewStyle;
     title?: TextStyle;
     description?: TextStyle;
     buttons?: ViewStyle;
@@ -107,6 +108,7 @@ export type ToasterProps = Omit<StyleProps, 'style'> & {
     unstyled?: boolean;
     toastContainerStyle?: ViewStyle;
     toastContentStyle?: ViewStyle;
+    contentWrapperStyle?: ViewStyle;
     buttonsStyle?: ViewStyle;
     closeButtonStyle?: ViewStyle;
     closeButtonIconStyle?: ViewStyle;

--- a/src/use-default-styles.ts
+++ b/src/use-default-styles.ts
@@ -5,6 +5,7 @@ import type { ToastVariant } from './types';
 type DefaultStyles = {
   toast: ViewStyle;
   toastContent: ViewStyle;
+  contentWrapper: ViewStyle;
   title: TextStyle;
   description: TextStyle;
   buttons: ViewStyle;
@@ -36,6 +37,7 @@ export const useDefaultStyles = ({
     return {
       toast: {},
       toastContent: {},
+      contentWrapper: {},
       title: {},
       description: {},
       buttons: {},
@@ -65,6 +67,9 @@ export const useDefaultStyles = ({
       flexDirection: 'row',
       gap: 16,
       alignItems: description?.length === 0 ? 'center' : undefined,
+    },
+    contentWrapper: {
+      flex: 1,
     },
     title: {
       fontWeight: '600',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Add customizable content wrapper style to `<ToastIcon />`

This change introduces a new optional prop `styles?.contentWrapper` applied to the outer <View> of <ToastIcon /> which previously had a fixed `flex: 1` style.

By allowing the caller to override or extend the wrapper style, this enables the toast text width to be adaptive based on its content, rather than always stretching to fill the available space.

This improvement enhances layout flexibility and better supports dynamic toast message lengths.

<img width="1910" height="1454" alt="image" src="https://github.com/user-attachments/assets/2fe3bd8b-9ee6-4882-b329-484d0a31ec72" />


https://github.com/user-attachments/assets/02e327be-8f15-4ae2-a4fe-45625cf19d6a




## Test plan

<!-- Provide instructions or files for testing the changes, especially if special setup is required. -->