### PR TITLE
Add ability to reset offsets (set to 0)

### DIFF
--- a/src/positioner.tsx
+++ b/src/positioner.tsx
@@ -32,11 +32,11 @@ export const Positioner: React.FC<
 
   const insetValues = React.useMemo(() => {
     if (position === 'bottom-center') {
-      return { bottom: offset || bottom || 40 };
+      return { bottom: offset ?? (bottom || 40) };
     }
 
     if (position === 'top-center') {
-      return { top: offset || top || 40 };
+      return { top: offset ?? (top || 40) };
     }
 
     return {};


### PR DESCRIPTION
## Summary

Currently, it's not possible to reset the default offsets on the `<Toaster />` component.

Due to the use of the OR operator (`||`) in [positioner.tsx#L35](https://github.com/gunnartorfis/sonner-native/blob/main/src/positioner.tsx#L35), when the offset prop is passed as `0` to the `Toaster` component, it is not applied. As a result, the `Positioner` component applies safe area insets regardless.

## Test Plan

Pass `offset={0}` to the `Toaster` component and verify that the default offset is reset (safe area insets are not applied).