### PR TITLE
fix(android): prevent touch blocking after toast auto-hide

### DIFF
--- a/src/gestures.tsx
+++ b/src/gestures.tsx
@@ -25,6 +25,7 @@ type ToastSwipeHandlerProps = Pick<ToastProps, 'important'> & {
   unstyled?: boolean;
   position?: ToastPosition;
   onPress: () => void;
+  isAndroidExiting: boolean;
 };
 
 export const ToastSwipeHandler: React.FC<
@@ -40,6 +41,7 @@ export const ToastSwipeHandler: React.FC<
   important,
   position: positionProps,
   onPress,
+  isAndroidExiting,
 }) => {
   const translate = useSharedValue(0);
   const {
@@ -208,6 +210,7 @@ export const ToastSwipeHandler: React.FC<
           style,
         ]}
         layout={LinearTransition.easing(easeInOutCircFn)}
+        pointerEvents={isAndroid && isAndroidExiting ? 'none' : 'auto'}
         aria-live={important ? 'assertive' : 'polite'} // https://reactnative.dev/docs/accessibility#aria-live-android
       >
         {children}


### PR DESCRIPTION
## Summary

Fixes an Android-only issue where the area under a toast becomes unpressable after the toast auto-hides.

## Test plan

I tested this in my own expo 53 app which experienced the same issue as described in #279 
I'm not able to reproduce it in the sample app. To test it I built the npm locally and installed in my own expo app. That fixed the issue.

**Disclosure**: AI was involved in finding and fixing the issue, since I do not know the code base very well I'm unsure if this is the correct way to fix it.