### PR TITLE
feat: allow styles to be passed to promise toasts through api

### DIFF
--- a/src/toast-fns.ts
+++ b/src/toast-fns.ts
@@ -50,6 +50,7 @@ toast.promise = (promise, options) => {
     ...options,
     title: options.loading,
     variant: 'info',
+    styles: options.styles?.loading,
     promiseOptions: {
       ...options,
       promise,

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -210,6 +210,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
               id,
               variant: 'success',
               promiseOptions: undefined,
+              styles: promiseOptions.styles?.success,
             });
           } catch (error) {
             addToast({
@@ -220,6 +221,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
               id,
               variant: 'error',
               promiseOptions: undefined,
+              styles: promiseOptions.styles?.error,
             });
           } finally {
             isResolvingPromise.current = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,21 @@
 import type React from 'react';
 import type { TextStyle, ViewProps, ViewStyle } from 'react-native';
 
+export type ToastStyles = {
+  toastContainer?: ViewStyle;
+  toast?: ViewStyle;
+  toastContent?: ViewStyle;
+  title?: TextStyle;
+  description?: TextStyle;
+  buttons?: ViewStyle;
+  closeButton?: ViewStyle;
+  closeButtonIcon?: ViewStyle;
+};
+
 type StyleProps = {
   unstyled?: boolean;
   style?: ViewStyle;
-  styles?: {
-    toastContainer?: ViewStyle;
-    toast?: ViewStyle;
-    toastContent?: ViewStyle;
-    title?: TextStyle;
-    description?: TextStyle;
-    buttons?: ViewStyle;
-    closeButton?: ViewStyle;
-    closeButtonIcon?: ViewStyle;
-  };
+  styles?: ToastStyles;
   backgroundComponent?: React.ReactNode;
 };
 
@@ -22,6 +24,11 @@ type PromiseOptions = {
   success: (result: any) => string; // TODO: type this with generics
   error: ((error: unknown) => string) | string;
   loading: string;
+  styles?: {
+    loading?: ToastStyles;
+    success?: ToastStyles;
+    error?: ToastStyles;
+  };
 };
 
 export type ToastPosition = 'top-center' | 'bottom-center' | 'center';


### PR DESCRIPTION
## Summary

Currently styles cannot be specified for promise toasts through the API, so there is no way to apply custom styles to each loading state variant. This means the method described in #178 is not possible for promise toasts.

This PR adds support for passing custom styles for each loading state through the promise api.

## Test plan

Apply different styles to each promise state:

```
toast.promise(
  fetch('/api/data'),
  {
    loading: 'Uploading...',
    success: (data) => `Uploaded ${data.filename}`,
    error: 'Upload failed',
    styles: {
      loading: {
        toast: { backgroundColor: '#3b82f6' },
        title: { color: 'white' },
      },
      success: {
        toast: { backgroundColor: '#22c55e' },
        title: { color: 'white', fontWeight: 'bold' },
      },
      error: {
        toast: { backgroundColor: '#ef4444', borderWidth: 2, borderColor: '#dc2626' },
        title: { color: 'white' },
        description: { color: '#fecaca' },
      },
    },
  }
);
```