### PR TITLE
fix: remove early return to resume timer after tap or slight drag

### DIFF
--- a/src/gestures.tsx
+++ b/src/gestures.tsx
@@ -98,7 +98,6 @@ export const ToastSwipeHandler: React.FC<
           translate.value = withTiming(0, {
             easing: Easing.elastic(0.8),
           });
-          return;
         }
 
         if (shouldDismiss) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->
This PR fixes issue mentioned here https://github.com/gunnartorfis/sonner-native/issues/283, where if user taps, or slightly drags the toast, it will end in isDraggin = true state, stopping close timer and never hiding. I've removed early return statement to allow toast to alway run cleanup, even after slight drag. 
## Summary
Motive is that in my company we stumbled upon this issue and the only way for us to get around this is to create patch package, but since more than 1 person had this issue, I've debugged and created this PR to address this.


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
## Test plan
Test gestures if the toast behave same in all scenarios 
<!-- Provide instructions or files for testing the changes, especially if special setup is required. -->