### PR TITLE
feat: allow toast text container to be styled

### DIFF
--- a/example/components/toasts-demo.tsx
+++ b/example/components/toasts-demo.tsx
@@ -481,6 +481,17 @@ export const ToastDemo: React.FC = () => {
           });
         }}
       />
+      <Button
+        title="Centered toast"
+        onPress={() => {
+          toast.success('Centered', {
+            styles: {
+              textContainer: { flex: 0 },
+              toast: { marginInline: 'auto' },
+            },
+          });
+        }}
+      />
     </ScrollView>
   );
 };

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -66,6 +66,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
         cancelButtonTextStyle: cancelButtonTextStyleCtx,
         style: toastStyleCtx,
         toastContentStyle: toastContentStyleCtx,
+        textContainerStyle: textContainerStyleCtx,
         titleStyle: titleStyleCtx,
         descriptionStyle: descriptionStyleCtx,
         buttonsStyle: buttonsStyleCtx,
@@ -420,7 +421,13 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                   richColors={richColors}
                 />
               )}
-              <View style={{ flex: 1 }}>
+              <View
+                style={[
+                  { flex: 1 },
+                  textContainerStyleCtx,
+                  styles?.textContainer,
+                ]}
+              >
                 <Text
                   style={[defaultStyles.title, titleStyleCtx, styles?.title]}
                 >

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -353,6 +353,10 @@ export const ToasterUI: React.FC<
                       ...props.styles?.toastContent,
                       ...toastToRender.styles?.toastContent,
                     },
+                    textContainer: {
+                      ...props.styles?.textContainer,
+                      ...toastToRender.styles?.textContainer,
+                    },
                     title: {
                       ...props.styles?.title,
                       ...toastToRender.styles?.title,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type ToastStyles = {
   toastContainer?: ViewStyle;
   toast?: ViewStyle;
   toastContent?: ViewStyle;
+  textContainer?: ViewStyle;
   title?: TextStyle;
   description?: TextStyle;
   buttons?: ViewStyle;
@@ -119,6 +120,7 @@ export type ToasterProps = Omit<StyleProps, 'style'> & {
     buttonsStyle?: ViewStyle;
     closeButtonStyle?: ViewStyle;
     closeButtonIconStyle?: ViewStyle;
+    textContainerStyle?: ViewStyle;
     backgroundComponent?: React.ReactNode;
     success?: ViewStyle;
     error?: ViewStyle;


### PR DESCRIPTION
## Summary

Add the ability to style the view that contains the title and description and buttons. This allows users to remove the hardcoded `{{flex: 1}}` and allows for things like centered toasts without content being cut off because of the flex styling.

This PR adds textContainerStyle to `ToastStyles` and `ToasterProps['toastOptions']`. It also adds a new example called "Centered Toast" that displays a centered toast. 

## Test plan

Just run the "Centered Toast" example or manually create a toast with textContainer in styles:

```
toast.success('Centered', {
  styles: {
    textContainer: { flex: 0 },
    toast: { marginInline: 'auto' },
  },
});
```