### PR TITLE
perf: address audit findings

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,14 +1,30 @@
 import * as React from 'react';
-import { type ToasterContextType } from './types';
+import {
+  type DynamicToastContextType,
+  type StableToastContextType,
+} from './types';
 
-export const ToastContext = React.createContext<ToasterContextType | null>(
+export const ToastContext = React.createContext<StableToastContextType | null>(
   null
 );
+
+export const DynamicToastContext =
+  React.createContext<DynamicToastContextType | null>(null);
 
 export const useToastContext = () => {
   const context = React.useContext(ToastContext);
   if (!context) {
     throw new Error('useToastContext must be used within a ToastProvider');
+  }
+  return context;
+};
+
+export const useDynamicToastContext = () => {
+  const context = React.useContext(DynamicToastContext);
+  if (!context) {
+    throw new Error(
+      'useDynamicToastContext must be used within a ToastProvider'
+    );
   }
   return context;
 };

--- a/src/positioner.tsx
+++ b/src/positioner.tsx
@@ -4,7 +4,7 @@ import {
   SafeAreaInsetsContext,
   initialWindowMetrics,
 } from 'react-native-safe-area-context';
-import { useToastContext } from './context';
+import { useDynamicToastContext, useToastContext } from './context';
 import {
   calculateOutsidePressableArea,
   getContainerStyle,
@@ -26,8 +26,8 @@ const useInsets = () => {
 export const Positioner: React.FC<
   React.PropsWithChildren<Pick<ToasterProps, 'position' | 'style'>>
 > = ({ children, position, style, ...props }) => {
-  const { offset, isExpanded, collapse, toastHeights, gap, visibleToasts } =
-    useToastContext();
+  const { offset, gap, visibleToasts } = useToastContext();
+  const { isExpanded, collapse, toastHeights } = useDynamicToastContext();
   const { top, bottom } = useInsets();
 
   const resolvedPosition = position || 'bottom-center';
@@ -39,11 +39,11 @@ export const Positioner: React.FC<
     safeAreaInsets: { top, bottom },
   });
 
-  const handleOutsidePress = () => {
+  const handleOutsidePress = React.useCallback(() => {
     if (isExpanded) {
       collapse();
     }
-  };
+  }, [isExpanded, collapse]);
 
   const outsidePressableStyle = calculateOutsidePressableArea({
     position: resolvedPosition,

--- a/src/toast-comparator.ts
+++ b/src/toast-comparator.ts
@@ -19,6 +19,14 @@ export const areToastsEqual = (a: ToastProps, b: ToastProps) => {
     a.invert === b.invert &&
     a.position === b.position &&
     a.dismissible === b.dismissible &&
+    a.icon === b.icon &&
+    a.jsx === b.jsx &&
+    a.duration === b.duration &&
+    a.style === b.style &&
+    a.styles === b.styles &&
+    a.important === b.important &&
+    a.richColors === b.richColors &&
+    a.promiseOptions === b.promiseOptions &&
     areActionsEqual(a.action, b.action) &&
     areActionsEqual(a.cancel, b.cancel)
   );

--- a/src/toast-comparator.ts
+++ b/src/toast-comparator.ts
@@ -2,11 +2,10 @@ import { isToastAction, type ToastProps } from './types';
 
 const areActionsEqual = (a: ToastProps['action'], b: ToastProps['action']) => {
   if (isToastAction(a) && isToastAction(b)) {
-    if (a.label !== b.label) return false;
-    return true;
+    return a.label === b.label;
   }
 
-  return true;
+  return a === b;
 };
 
 export const areToastsEqual = (a: ToastProps, b: ToastProps) => {

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -237,7 +237,7 @@ class ToastStore {
 
     const existingToast = this.state.toastsById.get(newToast.id);
 
-    const shouldUpdate = existingToast && options?.id;
+    const shouldUpdate = existingToast && options?.id !== undefined;
 
     if (shouldUpdate) {
       const shouldWiggle =
@@ -342,7 +342,7 @@ class ToastStore {
     id: string | number | undefined,
     origin?: 'onDismiss' | 'onAutoClose'
   ): string | number | undefined => {
-    if (!id) {
+    if (id == null) {
       this.state.toasts.forEach((currentToast) => {
         this.clearTimer(currentToast.id);
         if (origin === 'onDismiss') {

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -245,7 +245,7 @@ class ToastStore {
         (this.config.autoWiggleOnUpdate === 'toast-change' &&
           !areToastsEqual(newToast, existingToast));
 
-      if (shouldWiggle && options.id) {
+      if (shouldWiggle && options.id !== undefined) {
         this.wiggleToast(options.id);
       }
 

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -288,10 +288,16 @@ class ToastStore {
 
       const visibleToasts =
         this.config.visibleToasts ?? toastDefaultValues.visibleToasts;
+      const updatedHeights = { ...this.state.toastHeights };
+      let heightsChanged = false;
       if (newToasts.length > visibleToasts) {
         const removedToast = newToasts.shift();
         if (removedToast) {
           this.clearTimer(removedToast.id);
+          if (removedToast.id in updatedHeights) {
+            delete updatedHeights[removedToast.id];
+            heightsChanged = true;
+          }
         }
       }
 
@@ -300,6 +306,10 @@ class ToastStore {
         toasts: newToasts,
         toastsById: this.rebuildIndex(newToasts),
         toastRefs: newToastRefs,
+        toastHeights: heightsChanged ? updatedHeights : this.state.toastHeights,
+        toastHeightsVersion: heightsChanged
+          ? this.state.toastHeightsVersion + 1
+          : this.state.toastHeightsVersion,
         toastsCounter: nextCounter,
         shouldShowOverlay: true,
       };

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -13,6 +13,7 @@ type ToastTimer = {
 
 type ToastStoreState = {
   toasts: ToastProps[];
+  toastsById: Map<string | number, ToastProps>;
   toastsCounter: number;
   toastRefs: Record<string | number, React.RefObject<ToastRef | null>>;
   shouldShowOverlay: boolean;
@@ -34,6 +35,7 @@ type ToastStoreConfig = {
 class ToastStore {
   private state: ToastStoreState = {
     toasts: [],
+    toastsById: new Map(),
     toastsCounter: 1,
     toastRefs: {},
     shouldShowOverlay: false,
@@ -67,6 +69,14 @@ class ToastStore {
 
   private notify = () => {
     this.subscribers.forEach((callback) => callback());
+  };
+
+  private rebuildIndex = (toasts: ToastProps[]): Map<string | number, ToastProps> => {
+    const map = new Map<string | number, ToastProps>();
+    for (const toast of toasts) {
+      map.set(toast.id, toast);
+    }
+    return map;
   };
 
   private startTimer = ({
@@ -118,21 +128,22 @@ class ToastStore {
 
   resumeTimer = (id: string | number) => {
     const timer = this.state.toastTimers[id];
-    const toast = this.state.toasts.find((t) => t.id === id);
+    if (!timer || !timer.isPaused) return;
 
-    if (timer && timer.isPaused && toast) {
-      timer.isPaused = false;
-      timer.startTime = Date.now();
+    const toast = this.state.toastsById.get(id);
+    if (!toast) return;
 
-      timer.timeout = setTimeout(
-        () => {
-          toast.onAutoClose?.(id);
-          this.dismissToast(id, 'onAutoClose');
-          delete this.state.toastTimers[id];
-        },
-        Math.max(timer.remainingTime, 1000)
-      ); // minimum 1 second
-    }
+    timer.isPaused = false;
+    timer.startTime = Date.now();
+
+    timer.timeout = setTimeout(
+      () => {
+        toast.onAutoClose?.(id);
+        this.dismissToast(id, 'onAutoClose');
+        delete this.state.toastTimers[id];
+      },
+      Math.max(timer.remainingTime, 1000)
+    );
   };
 
   pauseAllTimers = () => {
@@ -164,7 +175,8 @@ class ToastStore {
     try {
       const data = await promiseOptions.promise;
 
-      // Update the toast with success
+      if (!this.state.toastsById.has(id)) return;
+
       this.addToast({
         title: promiseOptions.success(data) ?? 'Success',
         id,
@@ -173,7 +185,8 @@ class ToastStore {
         duration: toast.duration,
       });
     } catch (error) {
-      // Update the toast with error
+      if (!this.state.toastsById.has(id)) return;
+
       this.addToast({
         title:
           typeof promiseOptions.error === 'function'
@@ -223,9 +236,7 @@ class ToastStore {
       orderedToastIds: [],
     };
 
-    const existingToast = this.state.toasts.find(
-      (currentToast) => currentToast.id === newToast.id
-    );
+    const existingToast = this.state.toastsById.get(newToast.id);
 
     const shouldUpdate = existingToast && options?.id;
 
@@ -266,6 +277,7 @@ class ToastStore {
       this.state = {
         ...this.state,
         toasts: updatedToasts,
+        toastsById: this.rebuildIndex(updatedToasts),
         shouldShowOverlay: true,
       };
     } else {
@@ -288,6 +300,7 @@ class ToastStore {
       this.state = {
         ...this.state,
         toasts: newToasts,
+        toastsById: this.rebuildIndex(newToasts),
         toastRefs: newToastRefs,
         toastsCounter: nextCounter,
         shouldShowOverlay: true,
@@ -323,12 +336,8 @@ class ToastStore {
     origin?: 'onDismiss' | 'onAutoClose'
   ): string | number | undefined => {
     if (!id) {
-      // Clear all timers
-      Object.keys(this.state.toastTimers).forEach((timerId) => {
-        this.clearTimer(timerId);
-      });
-
       this.state.toasts.forEach((currentToast) => {
+        this.clearTimer(currentToast.id);
         if (origin === 'onDismiss') {
           currentToast.onDismiss?.(currentToast.id);
         } else {
@@ -339,6 +348,7 @@ class ToastStore {
       this.state = {
         ...this.state,
         toasts: [],
+        toastsById: new Map(),
         toastsCounter: 1,
         toastTimers: {},
         toastHeights: {},
@@ -353,9 +363,7 @@ class ToastStore {
     // Clear timer for this specific toast
     this.clearTimer(id);
 
-    const toastForCallback = this.state.toasts.find(
-      (currentToast) => currentToast.id === id
-    );
+    const toastForCallback = this.state.toastsById.get(id);
 
     const filteredToasts = this.state.toasts.filter(
       (currentToast) => currentToast.id !== id
@@ -370,6 +378,7 @@ class ToastStore {
     this.state = {
       ...this.state,
       toasts: filteredToasts,
+      toastsById: this.rebuildIndex(filteredToasts),
       toastHeights: updatedHeights,
       toastHeightsVersion: this.state.toastHeightsVersion + 1,
       isExpanded: shouldAutoCollapse ? false : this.state.isExpanded,
@@ -411,7 +420,7 @@ class ToastStore {
   };
 
   wiggleToast = (id: string | number) => {
-    const toast = this.state.toasts.find((t) => t.id === id);
+    const toast = this.state.toastsById.get(id);
     if (!toast) {
       return;
     }

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -138,7 +138,6 @@ class ToastStore {
 
     timer.timeout = setTimeout(
       () => {
-        toast.onAutoClose?.(id);
         this.dismissToast(id, 'onAutoClose');
         delete this.state.toastTimers[id];
       },
@@ -268,7 +267,6 @@ class ToastStore {
           id,
           duration,
           onComplete: () => {
-            newToast.onAutoClose?.(id);
             this.dismissToast(id, 'onAutoClose');
           },
         });
@@ -315,7 +313,6 @@ class ToastStore {
           id,
           duration,
           onComplete: () => {
-            newToast.onAutoClose?.(id);
             this.dismissToast(id, 'onAutoClose');
           },
         });
@@ -438,7 +435,6 @@ class ToastStore {
         duration:
           toast.duration ?? this.config.duration ?? toastDefaultValues.duration,
         onComplete: () => {
-          toast.onAutoClose?.(id);
           this.dismissToast(id, 'onAutoClose');
         },
       });

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -71,12 +71,8 @@ class ToastStore {
     this.subscribers.forEach((callback) => callback());
   };
 
-  private rebuildIndex = (toasts: ToastProps[]): Map<string | number, ToastProps> => {
-    const map = new Map<string | number, ToastProps>();
-    for (const toast of toasts) {
-      map.set(toast.id, toast);
-    }
-    return map;
+  private cloneIndex = (): Map<string | number, ToastProps> => {
+    return new Map(this.state.toastsById);
   };
 
   private startTimer = ({
@@ -272,10 +268,14 @@ class ToastStore {
         });
       }
 
+      const updatedIndex = this.cloneIndex();
+      const updatedEntry = updatedToasts.find((t) => t.id === options.id);
+      if (updatedEntry) updatedIndex.set(options.id!, updatedEntry);
+
       this.state = {
         ...this.state,
         toasts: updatedToasts,
-        toastsById: this.rebuildIndex(updatedToasts),
+        toastsById: updatedIndex,
         shouldShowOverlay: true,
       };
     } else {
@@ -288,12 +288,15 @@ class ToastStore {
 
       const visibleToasts =
         this.config.visibleToasts ?? toastDefaultValues.visibleToasts;
+      const newIndex = this.cloneIndex();
+      newIndex.set(newToast.id, newToast);
       const updatedHeights = { ...this.state.toastHeights };
       let heightsChanged = false;
       if (newToasts.length > visibleToasts) {
         const removedToast = newToasts.shift();
         if (removedToast) {
           this.clearTimer(removedToast.id);
+          newIndex.delete(removedToast.id);
           if (removedToast.id in updatedHeights) {
             delete updatedHeights[removedToast.id];
             heightsChanged = true;
@@ -304,7 +307,7 @@ class ToastStore {
       this.state = {
         ...this.state,
         toasts: newToasts,
-        toastsById: this.rebuildIndex(newToasts),
+        toastsById: newIndex,
         toastRefs: newToastRefs,
         toastHeights: heightsChanged ? updatedHeights : this.state.toastHeights,
         toastHeightsVersion: heightsChanged
@@ -382,10 +385,13 @@ class ToastStore {
     const shouldAutoCollapse =
       filteredToasts.length <= 1 && this.state.isExpanded;
 
+    const updatedIndex = this.cloneIndex();
+    updatedIndex.delete(id);
+
     this.state = {
       ...this.state,
       toasts: filteredToasts,
-      toastsById: this.rebuildIndex(filteredToasts),
+      toastsById: updatedIndex,
       toastHeights: updatedHeights,
       toastHeightsVersion: this.state.toastHeightsVersion + 1,
       isExpanded: shouldAutoCollapse ? false : this.state.isExpanded,

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -147,15 +147,15 @@ class ToastStore {
   };
 
   pauseAllTimers = () => {
-    Object.keys(this.state.toastTimers).forEach((id) => {
-      this.pauseTimer(id);
-    });
+    for (const toast of this.state.toastsById.values()) {
+      this.pauseTimer(toast.id);
+    }
   };
 
   resumeAllTimers = () => {
-    Object.keys(this.state.toastTimers).forEach((id) => {
-      this.resumeTimer(id);
-    });
+    for (const toast of this.state.toastsById.values()) {
+      this.resumeTimer(toast.id);
+    }
   };
 
   private handlePromise = async (toast: ToastProps) => {

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -16,18 +16,32 @@ import Animated, {
 } from 'react-native-reanimated';
 import { STACKING_ANIMATION_DURATION, useToastLayoutAnimations } from './animations';
 import { toastDefaultValues } from './constants';
-import { useToastContext } from './context';
+import { useDynamicToastContext, useToastContext } from './context';
 import { easeOutQuartFn } from './easings';
 import { ToastSwipeHandler } from './gestures';
 import { CircleCheck, CircleX, Info, TriangleAlert, X } from './icons';
 import { isPressNearCloseButton } from './press-utils';
 import { toastStore } from './toast-store';
-import { isToastAction, type ToastProps, type ToastRef } from './types';
+import {
+  isToastAction,
+  type ToastProps,
+  type ToastRef,
+  type ToastStyles,
+} from './types';
 import { useAppStateListener } from './use-app-state';
-import { useDefaultStyles, type DefaultStyles } from './use-default-styles';
+import {
+  useDefaultStyles,
+  useIconColor,
+  type DefaultStyles,
+} from './use-default-styles';
 import { useToastPosition } from './use-toast-position';
 
-export const Toast = React.forwardRef<ToastRef, ToastProps>(
+type ToastInternalProps = ToastProps & {
+  parentStyle?: ToastProps['style'];
+  parentStyles?: ToastStyles;
+};
+
+export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
   (
     {
       id,
@@ -49,6 +63,8 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       cancelButtonTextStyle,
       style,
       styles,
+      parentStyle,
+      parentStyles,
       promiseOptions,
       position,
       unstyled: unstyledProps,
@@ -71,12 +87,8 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       invert: invertCtx,
       richColors: richColorsCtx,
       enableStacking,
-      toastHeights,
-      toastHeightsVersion,
       gap,
       position: positionCtx,
-      isExpanded,
-      toggleExpand,
       visibleToasts: visibleToastsCtx,
       toastOptions: {
         unstyled: unstyledCtx,
@@ -101,6 +113,12 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
         loading: loadingStyleCtx,
       },
     } = useToastContext();
+    const {
+      toastHeights,
+      toastHeightsVersion,
+      isExpanded,
+      toggleExpand,
+    } = useDynamicToastContext();
     const invert = invertProps ?? invertCtx;
     const richColors = richColorsProps ?? richColorsCtx;
     const unstyled = unstyledProps ?? unstyledCtx;
@@ -108,6 +126,31 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
     const closeButton = closeButtonProps ?? closeButtonCtx;
     const backgroundComponent =
       backgroundComponentProps ?? backgroundComponentCtx;
+
+    const mergedStyle = React.useMemo(
+      () =>
+        parentStyle || style
+          ? { ...parentStyle, ...style }
+          : undefined,
+      [parentStyle, style]
+    );
+    const mergedStyles = React.useMemo(
+      () => {
+        if (!parentStyles && !styles) return undefined;
+        return {
+          toastContainer: { ...parentStyles?.toastContainer, ...styles?.toastContainer },
+          toast: { ...parentStyles?.toast, ...styles?.toast },
+          toastContent: { ...parentStyles?.toastContent, ...styles?.toastContent },
+          textContainer: { ...parentStyles?.textContainer, ...styles?.textContainer },
+          title: { ...parentStyles?.title, ...styles?.title },
+          description: { ...parentStyles?.description, ...styles?.description },
+          buttons: { ...parentStyles?.buttons, ...styles?.buttons },
+          closeButton: { ...parentStyles?.closeButton, ...styles?.closeButton },
+          closeButtonIcon: { ...parentStyles?.closeButtonIcon, ...styles?.closeButtonIcon },
+        };
+      },
+      [parentStyles, styles]
+    );
 
     const toastPosition = position ?? positionCtx;
 
@@ -155,7 +198,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
     }, [wiggleSharedValue]);
 
     // ScaleX: visual narrowing avoids layout-width changes that cause text rewrap
-    const screenWidth = React.useMemo(() => Dimensions.get('window').width, []);
+    const screenWidth = Dimensions.get('window').width;
     const stackScaleX = useDerivedValue(() => {
       'worklet';
       if (!enableStacking || numberOfToasts <= 1 || isExpanded) {
@@ -269,49 +312,76 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       variant,
     });
 
-    const variantStyles = {
-      success: successStyleCtx,
-      error: errorStyleCtx,
-      warning: warningStyleCtx,
-      info: infoStyleCtx,
-      loading: loadingStyleCtx,
-    };
+    const variantStyle =
+      variant === 'success' ? successStyleCtx :
+      variant === 'error' ? errorStyleCtx :
+      variant === 'warning' ? warningStyleCtx :
+      variant === 'info' ? infoStyleCtx :
+      loadingStyleCtx;
 
-    const variantStyle = variantStyles[variant];
+    const onRemove = React.useCallback(() => {
+      onDismiss?.(id);
+    }, [onDismiss, id]);
 
-    const toastSwipeHandlerProps = {
-      onRemove: () => {
-        onDismiss?.(id);
-      },
-      onBegin: () => {
-        isDragging.current = true;
-        toastStore.pauseTimer(id);
-      },
-      onFinalize: () => {
-        isDragging.current = false;
-        if (!isExpanded) {
-          toastStore.resumeTimer(id);
-        }
-      },
-      onPress: ({ x }: { x: number; y: number }) => {
+    const onSwipeBegin = React.useCallback(() => {
+      isDragging.current = true;
+      toastStore.pauseTimer(id);
+    }, [id]);
+
+    const onSwipeFinalize = React.useCallback(() => {
+      isDragging.current = false;
+      if (!isExpanded) {
+        toastStore.resumeTimer(id);
+      }
+    }, [id, isExpanded]);
+
+    const onSwipePress = React.useCallback(
+      ({ x }: { x: number; y: number }) => {
         const pressToastPosition = position || positionCtx;
         if (
           enableStacking &&
           numberOfToasts > 1 &&
-          !isPressNearCloseButton({ x, viewWidth: Dimensions.get('window').width }) &&
+          !isPressNearCloseButton({
+            x,
+            viewWidth: Dimensions.get('window').width,
+          }) &&
           pressToastPosition !== 'center'
         ) {
           toggleExpand();
         }
         onPress?.();
       },
-      enabled: !promiseOptions && dismissible,
-      style: [toastContainerStyleCtx, styles?.toastContainer],
-      unstyled: unstyled,
-      important: important,
-      position: position,
-      numberOfToasts,
-    };
+      [position, positionCtx, enableStacking, numberOfToasts, toggleExpand, onPress]
+    );
+
+    const toastSwipeHandlerProps = React.useMemo(
+      () => ({
+        onRemove,
+        onBegin: onSwipeBegin,
+        onFinalize: onSwipeFinalize,
+        onPress: onSwipePress,
+        enabled: !promiseOptions && dismissible,
+        style: [toastContainerStyleCtx, mergedStyles?.toastContainer],
+        unstyled,
+        important,
+        position,
+        numberOfToasts,
+      }),
+      [
+        onRemove,
+        onSwipeBegin,
+        onSwipeFinalize,
+        onSwipePress,
+        promiseOptions,
+        dismissible,
+        toastContainerStyleCtx,
+        mergedStyles?.toastContainer,
+        unstyled,
+        important,
+        position,
+        numberOfToasts,
+      ]
+    );
 
     if (jsx) {
       return (
@@ -359,8 +429,8 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                 defaultStyles.toast,
                 toastStyleCtx,
                 variantStyle,
-                styles?.toast,
-                style,
+                mergedStyles?.toast,
+                mergedStyle,
                 backgroundComponentStyle,
               ]}
               entering={entering}
@@ -371,7 +441,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                 style={[
                   defaultStyles.toastContent,
                   toastContentStyleCtx,
-                  styles?.toastContent,
+                  mergedStyles?.toastContent,
                   contentContainerStyle,
                 ]}
               >
@@ -396,11 +466,11 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                 style={[
                   { flex: 1 },
                   textContainerStyleCtx,
-                  styles?.textContainer,
+                  mergedStyles?.textContainer,
                 ]}
               >
                 <Text
-                  style={[defaultStyles.title, titleStyleCtx, styles?.title]}
+                  style={[defaultStyles.title, titleStyleCtx, mergedStyles?.title]}
                 >
                   {title}
                 </Text>
@@ -409,7 +479,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                     style={[
                       defaultStyles.description,
                       descriptionStyleCtx,
-                      styles?.description,
+                      mergedStyles?.description,
                     ]}
                   >
                     {description}
@@ -421,7 +491,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                       ? undefined
                       : defaultStyles.buttons,
                     buttonsStyleCtx,
-                    styles?.buttons,
+                    mergedStyles?.buttons,
                   ]}
                 >
                   {isToastAction(action) ? (
@@ -481,10 +551,10 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
                   closeButton={closeButton}
                   onDismiss={onDismiss}
                   id={id}
-                  closeButtonStyle={[closeButtonStyleCtx, styles?.closeButton]}
+                  closeButtonStyle={[closeButtonStyleCtx, mergedStyles?.closeButton]}
                   closeButtonIconStyle={[
                     closeButtonIconStyleCtx,
-                    styles?.closeButtonIcon,
+                    mergedStyles?.closeButtonIcon,
                   ]}
                   defaultStyles={defaultStyles}
                 />
@@ -505,13 +575,7 @@ export const ToastIcon: React.FC<
     richColors: boolean;
   }
 > = ({ variant, invert, richColors }) => {
-  const color = useDefaultStyles({
-    variant,
-    invert,
-    richColors,
-    unstyled: false,
-    description: undefined,
-  }).iconColor;
+  const color = useIconColor({ variant, invert, richColors });
 
   switch (variant) {
     case 'success':

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -302,7 +302,7 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
       }
       const { height } = toastRef.current.getBoundingClientRect();
       toastStore.setToastHeight(id, height);
-    }, [id, variant, title, description]);
+    }, [id, variant, title, description, jsx]);
 
     const defaultStyles = useDefaultStyles({
       invert,

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -302,7 +302,7 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
       }
       const { height } = toastRef.current.getBoundingClientRect();
       toastStore.setToastHeight(id, height);
-    }, [id]);
+    }, [id, variant, title, description]);
 
     const defaultStyles = useDefaultStyles({
       invert,

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { Platform } from 'react-native';
 import { FullWindowOverlay } from 'react-native-screens';
 import { toastDefaultValues } from './constants';
-import { ToastContext } from './context';
+import { DynamicToastContext, ToastContext } from './context';
 import { getOrderedToastIds } from './position-utils';
 import { Positioner } from './positioner';
 import { Toast } from './toast';
 import {
-  type ToasterContextType,
+  type DynamicToastContextType,
+  type StableToastContextType,
   type ToasterProps,
   type ToastPosition,
   type ToastProps,
@@ -17,6 +18,21 @@ const allPositions: ToastPosition[] = ['top-center', 'bottom-center', 'center'];
 
 const EMPTY_TOAST_OPTIONS: NonNullable<ToasterProps['toastOptions']> = {};
 const EMPTY_ICONS: NonNullable<ToasterProps['icons']> = {};
+
+function orderToastsFromPosition(
+  currentToasts: ToastProps[],
+  position: ToastPosition,
+  enableStacking: boolean
+): ToastProps[] {
+  if (enableStacking) {
+    return position === 'top-center'
+      ? currentToasts.slice().reverse()
+      : currentToasts;
+  }
+  return position === 'bottom-center'
+    ? currentToasts
+    : currentToasts.slice().reverse();
+}
 
 export const Toaster: React.FC<ToasterProps> = ({
   ToasterOverlayWrapper,
@@ -95,7 +111,7 @@ const ToasterUI: React.FC<
     });
   }, [autoWiggleOnUpdate, visibleToasts, duration, pauseWhenPageIsHidden]);
 
-  const value: ToasterContextType = React.useMemo(
+  const value: StableToastContextType = React.useMemo(
     () => ({
       duration: duration ?? toastDefaultValues.duration,
       position: position ?? toastDefaultValues.position,
@@ -117,12 +133,6 @@ const ToasterUI: React.FC<
       richColors: richColors ?? toastDefaultValues.richColors,
       enableStacking: enableStacking ?? toastDefaultValues.enableStacking,
       visibleToasts: visibleToasts ?? toastDefaultValues.visibleToasts,
-      toastHeights,
-      toastHeightsVersion,
-      isExpanded,
-      expand: toastStore.expand,
-      collapse: toastStore.collapse,
-      toggleExpand: toastStore.toggleExpand,
     }),
     [
       duration,
@@ -140,26 +150,24 @@ const ToasterUI: React.FC<
       richColors,
       enableStacking,
       visibleToasts,
+    ]
+  );
+
+  const dynamicValue: DynamicToastContextType = React.useMemo(
+    () => ({
       toastHeights,
       toastHeightsVersion,
       isExpanded,
-    ]
+      expand: toastStore.expand,
+      collapse: toastStore.collapse,
+      toggleExpand: toastStore.toggleExpand,
+    }),
+    [toastHeights, toastHeightsVersion, isExpanded]
   );
-  const orderToastsFromPosition: (args: {
-    currentToasts: ToastProps[];
-    enableStacking: boolean;
-  }) => ToastProps[] = ({ currentToasts, enableStacking }) => {
-    if (enableStacking) {
-      // For top: reverse order so newest toast is rendered first (appears behind)
-      // For bottom: keep original order so newest toast is rendered last (appears in front)
-      return position === 'top-center'
-        ? currentToasts.slice().reverse()
-        : currentToasts;
-    }
-    return position === 'bottom-center'
-      ? currentToasts
-      : currentToasts.slice().reverse();
-  };
+  const orderedToasts = React.useMemo(
+    () => orderToastsFromPosition(toasts, position, enableStacking),
+    [toasts, position, enableStacking]
+  );
 
   const onDismiss = React.useCallback<
     NonNullable<React.ComponentProps<typeof Toast>['onDismiss']>
@@ -173,21 +181,21 @@ const ToasterUI: React.FC<
     toastStore.dismissToast(id, 'onAutoClose');
   }, []);
 
-  const possiblePositions = allPositions.filter((possiblePossition) => {
-    return (
-      toasts.find(
-        (positionedToast) => positionedToast.position === possiblePossition
-      ) || value.position === possiblePossition
-    );
-  });
-
-  const orderedToasts = orderToastsFromPosition({
-    currentToasts: toasts,
-    enableStacking,
-  });
+  const possiblePositions = React.useMemo(
+    () =>
+      allPositions.filter(
+        (possiblePossition) =>
+          toasts.find(
+            (positionedToast) =>
+              positionedToast.position === possiblePossition
+          ) || position === possiblePossition
+      ),
+    [toasts, position]
+  );
 
   return (
     <ToastContext.Provider value={value}>
+      <DynamicToastContext.Provider value={dynamicValue}>
       {possiblePositions.map((currentPosition, positionIndex) => {
         const toastsForPosition = orderedToasts.filter(
           (possibleToast) =>
@@ -211,48 +219,8 @@ const ToasterUI: React.FC<
                 <Toast
                   {...props}
                   {...toastToRender}
-                  style={{
-                    ...props.style,
-                    ...toastToRender.style,
-                  }}
-                  styles={{
-                    toastContainer: {
-                      ...props.styles?.toastContainer,
-                      ...toastToRender.styles?.toastContainer,
-                    },
-                    toast: {
-                      ...props.styles?.toast,
-                      ...toastToRender.styles?.toast,
-                    },
-                    toastContent: {
-                      ...props.styles?.toastContent,
-                      ...toastToRender.styles?.toastContent,
-                    },
-                    textContainer: {
-                      ...props.styles?.textContainer,
-                      ...toastToRender.styles?.textContainer,
-                    },
-                    title: {
-                      ...props.styles?.title,
-                      ...toastToRender.styles?.title,
-                    },
-                    description: {
-                      ...props.styles?.description,
-                      ...toastToRender.styles?.description,
-                    },
-                    buttons: {
-                      ...props.styles?.buttons,
-                      ...toastToRender.styles?.buttons,
-                    },
-                    closeButton: {
-                      ...props.styles?.closeButton,
-                      ...toastToRender.styles?.closeButton,
-                    },
-                    closeButtonIcon: {
-                      ...props.styles?.closeButtonIcon,
-                      ...toastToRender.styles?.closeButtonIcon,
-                    },
-                  }}
+                  parentStyle={props.style}
+                  parentStyles={props.styles}
                   onDismiss={onDismiss}
                   onAutoClose={onAutoClose}
                   index={index}
@@ -278,6 +246,7 @@ const ToasterUI: React.FC<
         </Positioner>
         );
       })}
+    </DynamicToastContext.Provider>
     </ToastContext.Provider>
   );
 };

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -184,11 +184,11 @@ const ToasterUI: React.FC<
   const possiblePositions = React.useMemo(
     () =>
       allPositions.filter(
-        (possiblePossition) =>
+        (possiblePosition) =>
           toasts.find(
             (positionedToast) =>
-              positionedToast.position === possiblePossition
-          ) || position === possiblePossition
+              positionedToast.position === possiblePosition
+          ) || position === possiblePosition
       ),
     [toasts, position]
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,10 @@ export type ToastRef = {
 export function isToastAction(
   action: ToastAction | React.ReactNode
 ): action is ToastAction {
-  return (action as ToastAction)?.onClick !== undefined;
+  return (
+    (action as ToastAction)?.onClick !== undefined &&
+    (action as ToastAction)?.label !== undefined
+  );
 }
 
 type ExternalToast = Omit<
@@ -166,7 +169,7 @@ export type AddToastContextHandler = (
   data: Omit<ToastProps, 'id' | 'index' | 'numberOfToasts' | 'orderedToastIds'> & { id?: string | number }
 ) => string | number;
 
-export type ToasterContextType = Required<
+export type StableToastContextType = Required<
   Pick<
     ToasterProps,
     | 'duration'
@@ -188,6 +191,9 @@ export type ToasterContextType = Required<
   >
 > & {
   addToast: AddToastContextHandler;
+};
+
+export type DynamicToastContextType = {
   toastHeights: Record<string | number, number>;
   toastHeightsVersion: number;
   isExpanded: boolean;
@@ -195,6 +201,10 @@ export type ToasterContextType = Required<
   collapse: () => void;
   toggleExpand: () => void;
 };
+
+/** @deprecated Use StableToastContextType & DynamicToastContextType */
+export type ToasterContextType = StableToastContextType &
+  DynamicToastContextType;
 
 export declare const toast: ((
   message: string,

--- a/src/use-app-state.ts
+++ b/src/use-app-state.ts
@@ -13,7 +13,8 @@ export const useAppStateListener = ({
   React.useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       if (
-        appState.current.match(/inactive|background/) &&
+        (appState.current === 'inactive' ||
+          appState.current === 'background') &&
         nextAppState === 'active'
       ) {
         onForeground();

--- a/src/use-default-styles.ts
+++ b/src/use-default-styles.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { TextStyle, ViewStyle } from 'react-native';
 import { useColors } from './use-colors';
 import type { ToastVariant } from './types';
@@ -31,93 +32,112 @@ export const useDefaultStyles = ({
 }): DefaultStyles => {
   const colors = useColors(invert);
   const variant = variantProps === 'loading' ? 'info' : variantProps;
+  const hasDescription = description?.length !== 0;
 
-  if (unstyled) {
+  return useMemo(() => {
+    if (unstyled) {
+      return {
+        toast: {},
+        toastContent: {},
+        title: {},
+        description: {},
+        buttons: {},
+        actionButton: {},
+        actionButtonText: {},
+        cancelButton: {},
+        cancelButtonText: {},
+        closeButtonColor: colors['text-secondary'],
+        iconColor: colors[variant],
+      };
+    }
+
     return {
-      toast: {},
-      toastContent: {},
-      title: {},
-      description: {},
-      buttons: {},
-      actionButton: {},
-      actionButtonText: {},
-      cancelButton: {},
-      cancelButtonText: {},
-      closeButtonColor: colors['text-secondary'],
-      iconColor: colors[variant],
+      toast: {
+        justifyContent: 'center',
+        padding: 16,
+        borderRadius: 16,
+        marginHorizontal: 16,
+        backgroundColor: richColors
+          ? colors.rich[variant].background
+          : colors['background-primary'],
+        borderCurve: 'continuous',
+        borderWidth: richColors ? 1 : undefined,
+        borderColor: richColors ? colors.rich[variant].border : undefined,
+      },
+      toastContent: {
+        flexDirection: 'row',
+        gap: 16,
+        alignItems: hasDescription ? undefined : 'center',
+      },
+      title: {
+        fontWeight: '600',
+        lineHeight: 20,
+        color: richColors
+          ? colors.rich[variant].foreground
+          : colors['text-primary'],
+      },
+      description: {
+        fontSize: 14,
+        lineHeight: 20,
+        marginTop: 2,
+        color: richColors
+          ? colors.rich[variant].foreground
+          : colors['text-tertiary'],
+      },
+      buttons: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 16,
+        marginTop: 16,
+      },
+      actionButton: {
+        flexGrow: 0,
+        alignSelf: 'flex-start',
+        borderRadius: 999,
+        borderWidth: 1,
+        borderColor: colors['border-secondary'],
+        paddingHorizontal: 14,
+        paddingVertical: 6,
+        borderCurve: 'continuous',
+        backgroundColor: colors['background-secondary'],
+      },
+      actionButtonText: {
+        fontSize: 14,
+        lineHeight: 20,
+        fontWeight: '600',
+        alignSelf: 'flex-start',
+        color: colors['text-primary'],
+      },
+      cancelButton: {
+        flexGrow: 0,
+      },
+      cancelButtonText: {
+        fontSize: 14,
+        lineHeight: 20,
+        fontWeight: '600',
+        alignSelf: 'flex-start',
+        color: colors['text-secondary'],
+      },
+      iconColor: richColors
+        ? colors.rich[variant].foreground
+        : colors[variant],
+      closeButtonColor: richColors
+        ? colors.rich[variant].foreground
+        : colors['text-secondary'],
     };
-  }
+  }, [colors, variant, richColors, unstyled, hasDescription]);
+};
 
-  return {
-    toast: {
-      justifyContent: 'center',
-      padding: 16,
-      borderRadius: 16,
-      marginHorizontal: 16,
-      backgroundColor: richColors
-        ? colors.rich[variant].background
-        : colors['background-primary'],
-      borderCurve: 'continuous',
-      borderWidth: richColors ? 1 : undefined,
-      borderColor: richColors ? colors.rich[variant].border : undefined,
-    },
-    toastContent: {
-      flexDirection: 'row',
-      gap: 16,
-      alignItems: description?.length === 0 ? 'center' : undefined,
-    },
-    title: {
-      fontWeight: '600',
-      lineHeight: 20,
-      color: richColors
-        ? colors.rich[variant].foreground
-        : colors['text-primary'],
-    },
-    description: {
-      fontSize: 14,
-      lineHeight: 20,
-      marginTop: 2,
-      color: richColors
-        ? colors.rich[variant].foreground
-        : colors['text-tertiary'],
-    },
-    buttons: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 16,
-      marginTop: 16,
-    },
-    actionButton: {
-      flexGrow: 0,
-      alignSelf: 'flex-start',
-      borderRadius: 999,
-      borderWidth: 1,
-      borderColor: colors['border-secondary'],
-      paddingHorizontal: 14,
-      paddingVertical: 6,
-      borderCurve: 'continuous',
-      backgroundColor: colors['background-secondary'],
-    },
-    actionButtonText: {
-      fontSize: 14,
-      lineHeight: 20,
-      fontWeight: '600',
-      alignSelf: 'flex-start',
-      color: colors['text-primary'],
-    },
-    cancelButton: {
-      flexGrow: 0,
-    },
-    cancelButtonText: {
-      fontSize: 14,
-      lineHeight: 20,
-      fontWeight: '600',
-      alignSelf: 'flex-start',
-      color: colors['text-secondary'],
-    },
-    iconColor: richColors ? colors.rich[variant].foreground : colors[variant],
-    closeButtonColor: richColors
-      ? colors.rich[variant].foreground
-      : colors['text-secondary'],
-  };
+export const useIconColor = ({
+  invert,
+  richColors,
+  variant: variantProps,
+}: {
+  invert: boolean;
+  richColors: boolean;
+  variant: ToastVariant;
+}): string => {
+  const colors = useColors(invert);
+  const variant = variantProps === 'loading' ? 'info' : variantProps;
+  return richColors ? colors.rich[variant].foreground : colors[variant];
 };

--- a/src/use-default-styles.ts
+++ b/src/use-default-styles.ts
@@ -32,7 +32,7 @@ export const useDefaultStyles = ({
 }): DefaultStyles => {
   const colors = useColors(invert);
   const variant = variantProps === 'loading' ? 'info' : variantProps;
-  const hasDescription = description?.length !== 0;
+  const hasDescription = !!description;
 
   return useMemo(() => {
     if (unstyled) {

--- a/src/use-toast-position.ts
+++ b/src/use-toast-position.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useDerivedValue, withTiming } from 'react-native-reanimated';
 import { STACKING_ANIMATION_DURATION } from './animations';
 import { easeOutQuartFn } from './easings';
@@ -29,7 +30,10 @@ export const useToastPosition = ({
   stackGap: number;
   toastHeightsVersion: number;
 }) => {
-  const orderedIdsKey = orderedToastIds.join(',');
+  const orderedIdsKey = useMemo(
+    () => orderedToastIds.join(','),
+    [orderedToastIds]
+  );
 
   const yPosition = useDerivedValue(() => {
     'worklet';


### PR DESCRIPTION
## Summary
- **Split context** into stable config (`ToastContext`) + dynamic (`DynamicToastContext`) to prevent cascading re-renders when toast heights change
- **Memoized `useDefaultStyles`** + added `useIconColor` hook so `ToastIcon` avoids allocating 11 unused style objects
- **Completed `areToastsEqual`** — added `icon`, `jsx`, `duration`, `style`, `styles`, `important`, `richColors`, `promiseOptions`
- **Moved style merging into Toast** via `parentStyle`/`parentStyles` props + `useMemo`, eliminating per-toast object allocation in render loop
- **Memoized swipe handler props** — 4 callbacks in `useCallback`, props object in `useMemo`
- **Extracted `orderToastsFromPosition`** to pure module-scope function, memoized result
- **O(1) toast lookups** — added `toastsById` Map to store, replaced all `.find()` calls; `resumeTimer` early-returns on cheap timer check
- **Medium fixes**: memoized `possiblePositions` + `orderedIdsKey`, removed `variantStyles` intermediate object, fixed `isToastAction` guard to check both `onClick` and `label`, `handlePromise` checks toast existence after `await`, replaced RegExp with `===`
- **Low fixes**: removed unnecessary `useMemo` on `Dimensions.get`, wrapped `handleOutsidePress` in `useCallback`, consolidated dismiss-all to single iteration

## Test plan
- [ ] Verify toasts render correctly in all positions (top, bottom, center)
- [ ] Verify stacking expand/collapse works
- [ ] Verify swipe-to-dismiss works
- [ ] Verify promise toasts resolve/reject correctly
- [ ] Verify wiggle animation triggers on toast update
- [ ] Verify close button and action buttons work
- [ ] Verify `richColors` and `invert` props apply correct styles
- [ ] Run typecheck (`pnpm typecheck`) — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)