### PR TITLE
Add React Native Screens link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ To use this package, **you also need to install its peer dependencies**. Check o
 - [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/)
 - [React Native Safe Area Context](https://docs.expo.dev/versions/latest/sdk/safe-area-context/)
 - [React Native SVG](https://github.com/software-mansion/react-native-svg)
+- [React Native Screens](https://github.com/software-mansion/react-native-screens)
 
 ## Usage
 


### PR DESCRIPTION
## Summary

It seems the docs assume use of react-navigation or expo-navigation (which require react-native-screens). None of these are required to use sonner-native-toasts. 

I recently installed in a non-expo app that doesn't use react-navigation and was met with react-native-screens missing related errors. These could easily be quite opaque & confusing to others. At a glance it looks like there's something wrong with sonner-native-toasts. 

Anyways, considering it is a peer dependency, it should probably be in the requirements list.