### PR TITLE
fix: skips animation when Reduce Motion is turned on

### DIFF
--- a/src/animations.ts
+++ b/src/animations.ts
@@ -1,4 +1,4 @@
-import { withTiming } from 'react-native-reanimated';
+import { useReducedMotion, withTiming } from 'react-native-reanimated';
 import { getEnteringTranslateY, getExitingTranslateY } from './animation-utils';
 import { toastDefaultValues } from './constants';
 import { useToastContext } from './context';
@@ -16,6 +16,11 @@ export const useToastLayoutAnimations = (
   const { position: positionCtx, gap } = useToastContext();
   const position = positionProp || positionCtx;
   const stackGap = gap ?? toastDefaultValues.stackGap;
+  const reducedMotion = useReducedMotion();
+
+  if (reducedMotion) {
+    return { entering: undefined, exiting: undefined };
+  }
 
   return {
     entering: () => {
@@ -24,7 +29,12 @@ export const useToastLayoutAnimations = (
     },
     exiting: () => {
       'worklet';
-      return getToastExiting({ position, isHiddenByLimit, numberOfToasts, stackGap });
+      return getToastExiting({
+        position,
+        isHiddenByLimit,
+        numberOfToasts,
+        stackGap,
+      });
     },
   };
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

When the system **Reduce Motion** setting is on, toasts never become visible. The function-style entering layout animation is still invoked by Reanimated, but `withStyleAnimation` with empty/no-op animations leaves `animation.current` as `{}` and pushes nothing to the native view, so the toast renders at its (invisible) initial values forever.

This PR gates `useToastLayoutAnimations` on `useReducedMotion()` and returns `undefined` for `entering`/`exiting` when reduce motion is enabled. `Animated.View` skips layout-animation registration entirely when those props are undefined, so the toast just mounts/unmounts as a plain View, which is the expected behavior for reduce-motion users.

Note: returning `{ initialValues, animations: {} }` looks like the obvious fix but doesn't work, Reanimated's `withStyleAnimation({})` walks an empty object, leaves `animation.current` as `{}`, and applies nothing.

## Test plan

<!-- Provide instructions or files for testing the changes, especially if special setup is required. -->

1. Enable **Settings -> Accessibility -> Motion -> Reduce Motion** on an iOS simulator/device (or the Android equivalent).
2. Run the example app and trigger a toast (`toast('hello')`).
3. Before this change: nothing visible. After this change: toast appears instantly and dismisses instantly 

- [ ], no animation, but visible.

4. Toggle Reduce Motion off and confirm the original entering/exiting animations still play normally.