### PR TITLE
Fix center toast position and stacking

### DIFF
--- a/src/__tests__/animation-utils.test.ts
+++ b/src/__tests__/animation-utils.test.ts
@@ -16,15 +16,14 @@ describe('animation-utils', () => {
       expect(result).toBe(50);
     });
 
-    it('should return 0 for center position', () => {
+    it('should return 50 for center position (mirrors bottom-center)', () => {
       const result = getEnteringTranslateY('center');
-      expect(result).toBe(0);
+      expect(result).toBe(50);
     });
 
-    it('should return 0 for any other position', () => {
-      // Test with an arbitrary position that should default to 0
+    it('should default to 50 for any other position', () => {
       const result = getEnteringTranslateY('bottom-left' as ToastPosition);
-      expect(result).toBe(0);
+      expect(result).toBe(50);
     });
   });
 
@@ -63,7 +62,7 @@ describe('animation-utils', () => {
         expect(result).toBe(150);
       });
 
-      it('should return 50 for center with single toast', () => {
+      it('should return 150 for center with single toast (mirrors bottom-center)', () => {
         const result = getExitingTranslateY({
           position: 'center',
           isHiddenByLimit: false,
@@ -71,7 +70,7 @@ describe('animation-utils', () => {
         stackGap: 8,
         });
 
-        expect(result).toBe(50);
+        expect(result).toBe(150);
       });
     });
 

--- a/src/__tests__/position-utils.test.ts
+++ b/src/__tests__/position-utils.test.ts
@@ -30,9 +30,9 @@ describe('position-utils', () => {
       expect(result).toEqual(['toast-3', 'toast-2', 'toast-1']);
     });
 
-    it('should return reversed order for center without stacking', () => {
+    it('should return normal order for center without stacking (mirrors bottom-center)', () => {
       const result = getOrderedToastIds(mockToasts, 'center', false);
-      expect(result).toEqual(['toast-3', 'toast-2', 'toast-1']);
+      expect(result).toEqual(['toast-1', 'toast-2', 'toast-3']);
     });
   });
 
@@ -165,22 +165,35 @@ describe('position-utils', () => {
 
     describe('center position', () => {
       const position: ToastPosition = 'center';
+      // Center anchors at top:50% with -frontHeight/2 shift so the front toast
+      // is visually centered on the screen midline. Front = toast-3 (height 80).
+      const centerShift = -40;
 
-      it('should calculate correct position for stacking mode', () => {
+      it('should center the front toast on the screen midline', () => {
         const result = calculateToastPosition({
           ...baseParams,
-          index: 1,
+          index: 2,
           enableStacking: true,
           position,
         });
 
-        // Center stacking: offset from center
-        // offsetFromCenter = stackGap * (numberOfToasts - index - 1)
-        // = 8 * (3 - 1 - 1) = 8 * 1 = 8
-        expect(result).toBe(8);
+        // Front toast (index 2): bottom-center calc = 0, plus centerShift = -40
+        expect(result).toBe(centerShift);
       });
 
-      it('should calculate correct position for non-stacking mode', () => {
+      it('should mirror bottom-center stacking offsets behind the front', () => {
+        const result = calculateToastPosition({
+          ...baseParams,
+          index: 0,
+          enableStacking: true,
+          position,
+        });
+
+        // bottom-center calc for index 0 = -36, plus centerShift = -40
+        expect(result).toBe(centerShift + -36);
+      });
+
+      it('should mirror bottom-center non-stacking layout', () => {
         const result = calculateToastPosition({
           ...baseParams,
           index: 1,
@@ -188,13 +201,11 @@ describe('position-utils', () => {
           position,
         });
 
-        // Center non-stacking: sum heights for previous toasts
-        // Height of toast-1 = 60, gap = 14
-        const expectedOffset = 60 + 14;
-        expect(result).toBe(expectedOffset);
+        // bottom-center non-stacking for index 1 = -(80 + 14) = -94, plus shift
+        expect(result).toBe(centerShift + -(80 + 14));
       });
 
-      it('should use gap in center non-stacking mode even when expanded', () => {
+      it('should use stackGap in expanded mode like bottom-center', () => {
         const result = calculateToastPosition({
           ...baseParams,
           index: 1,
@@ -204,10 +215,7 @@ describe('position-utils', () => {
           stackGap: 8,
         });
 
-        // Center non-stacking always uses gap (not stackGap)
-        // Height of toast-1 = 60, gap = 14
-        const expectedOffset = 60 + 14;
-        expect(result).toBe(expectedOffset);
+        expect(result).toBe(centerShift + -(80 + 8));
       });
     });
 

--- a/src/__tests__/positioner-utils.test.ts
+++ b/src/__tests__/positioner-utils.test.ts
@@ -12,11 +12,9 @@ describe('positioner-utils', () => {
 
       expect(result).toEqual({
         position: 'absolute',
-        top: 0,
-        bottom: 0,
+        top: '50%',
         left: 0,
         right: 0,
-        justifyContent: 'center',
         alignItems: 'center',
         overflow: 'visible',
       });

--- a/src/animation-utils.ts
+++ b/src/animation-utils.ts
@@ -6,11 +6,8 @@ export const getEnteringTranslateY = (position: ToastPosition): number => {
     return -20;
   }
 
-  if (position === 'bottom-center') {
-    return 50;
-  }
-
-  return 0;
+  // bottom-center and center share the same enter direction (slide up from below)
+  return 50;
 };
 
 export const getExitingTranslateY = ({
@@ -33,17 +30,12 @@ export const getExitingTranslateY = ({
     if (position === 'top-center') {
       return -150;
     }
-    if (position === 'bottom-center') {
-      return 150;
-    }
-    return 50;
+    // bottom-center and center
+    return 150;
   }
 
   if (position === 'top-center') {
     return -stackGap;
-  }
-  if (position === 'bottom-center') {
-    return stackGap;
   }
   return stackGap;
 };

--- a/src/position-utils.ts
+++ b/src/position-utils.ts
@@ -10,9 +10,9 @@ export const getOrderedToastIds = (
     // toasts are already in rendering order (reversed by orderToastsFromPosition for top-center)
     return toasts.map((t) => t.id);
   }
-  return position === 'bottom-center'
-    ? toasts.map((t) => t.id)
-    : toasts.map((t) => t.id).reverse();
+  return position === 'top-center'
+    ? toasts.map((t) => t.id).reverse()
+    : toasts.map((t) => t.id);
 };
 
 export const calculateToastPosition = ({
@@ -39,64 +39,58 @@ export const calculateToastPosition = ({
   'worklet';
   const effectiveEnableStacking = enableStacking && !isExpanded;
 
-  if (position === 'center') {
-    if (effectiveEnableStacking) {
-      const offsetFromCenter = stackGap * (numberOfToasts - index - 1);
-      return offsetFromCenter;
-    } else {
-      const effectiveGap = gap;
-      let totalOffset = 0;
-      for (let i = 0; i < index; i++) {
-        const toastId = orderedToastIds[i];
-        if (!toastId) {
-          continue;
-        }
-        const height = allToastHeights[toastId] || ESTIMATED_TOAST_HEIGHT;
-        totalOffset += height + effectiveGap;
-      }
-      return totalOffset;
-    }
-  }
+  // Center anchors at top:50% of the screen (top edge of toast = center line).
+  // Shift by -frontHeight/2 so the front toast is visually centered on the line.
+  const centerShift =
+    position === 'center'
+      ? -(
+          (allToastHeights[orderedToastIds[numberOfToasts - 1]!] ||
+            ESTIMATED_TOAST_HEIGHT) / 2
+        )
+      : 0;
 
   if (effectiveEnableStacking) {
     const currentId = orderedToastIds[index];
     const currentHeight = allToastHeights[currentId!] || ESTIMATED_TOAST_HEIGHT;
 
-    if (position === 'bottom-center') {
-      const frontId = orderedToastIds[numberOfToasts - 1];
+    if (position === 'top-center') {
+      const frontId = orderedToastIds[0];
       const frontHeight = allToastHeights[frontId!] || ESTIMATED_TOAST_HEIGHT;
-      const distFromFront = numberOfToasts - 1 - index;
-      return -(frontHeight + distFromFront * stackGap - currentHeight);
+      return frontHeight + index * stackGap - currentHeight;
     }
-    // top-center
-    const frontId = orderedToastIds[0];
+    // bottom-center and center
+    const frontId = orderedToastIds[numberOfToasts - 1];
     const frontHeight = allToastHeights[frontId!] || ESTIMATED_TOAST_HEIGHT;
-    return frontHeight + index * stackGap - currentHeight;
-  } else {
-    const effectiveGap = isExpanded ? stackGap : gap;
-
-    if (position === 'bottom-center') {
-      let totalOffset = 0;
-      for (let i = numberOfToasts - 1; i > index; i--) {
-        const toastId = orderedToastIds[i];
-        if (!toastId) {
-          continue;
-        }
-        const height = allToastHeights[toastId] || ESTIMATED_TOAST_HEIGHT;
-        totalOffset += height + effectiveGap;
-      }
-      return -totalOffset;
-    } else {
-      let totalOffset = 0;
-      for (let i = 0; i < index; i++) {
-        const toastId = orderedToastIds[i];
-        if (!toastId) {
-          continue;
-        }
-        const height = allToastHeights[toastId] || ESTIMATED_TOAST_HEIGHT;
-        totalOffset += height + effectiveGap;
-      }
-      return totalOffset;
-    }
+    const distFromFront = numberOfToasts - 1 - index;
+    return (
+      centerShift - (frontHeight + distFromFront * stackGap - currentHeight)
+    );
   }
+
+  const effectiveGap = isExpanded ? stackGap : gap;
+
+  if (position === 'top-center') {
+    let totalOffset = 0;
+    for (let i = 0; i < index; i++) {
+      const toastId = orderedToastIds[i];
+      if (!toastId) {
+        continue;
+      }
+      const height = allToastHeights[toastId] || ESTIMATED_TOAST_HEIGHT;
+      totalOffset += height + effectiveGap;
+    }
+    return totalOffset;
+  }
+
+  // bottom-center and center
+  let totalOffset = 0;
+  for (let i = numberOfToasts - 1; i > index; i--) {
+    const toastId = orderedToastIds[i];
+    if (!toastId) {
+      continue;
+    }
+    const height = allToastHeights[toastId] || ESTIMATED_TOAST_HEIGHT;
+    totalOffset += height + effectiveGap;
+  }
+  return centerShift - totalOffset;
 };

--- a/src/positioner-utils.ts
+++ b/src/positioner-utils.ts
@@ -6,11 +6,9 @@ export const getContainerStyle = (position: ToastPosition): ViewStyle => {
   if (position === 'center') {
     return {
       position: 'absolute',
-      top: 0,
-      bottom: 0,
+      top: '50%',
       left: 0,
       right: 0,
-      justifyContent: 'center',
       alignItems: 'center',
       overflow: 'visible',
     };

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -209,7 +209,7 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
       }
 
       const multiplier =
-        toastPosition === 'top-center' || toastPosition === 'center'
+        toastPosition === 'top-center'
           ? index
           : numberOfToasts - index - 1;
       const narrowAmount = stackGap * multiplier * 2;

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -29,9 +29,9 @@ function orderToastsFromPosition(
       ? currentToasts.slice().reverse()
       : currentToasts;
   }
-  return position === 'bottom-center'
-    ? currentToasts
-    : currentToasts.slice().reverse();
+  return position === 'top-center'
+    ? currentToasts.slice().reverse()
+    : currentToasts;
 }
 
 export const Toaster: React.FC<ToasterProps> = ({

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -21,14 +21,8 @@ const EMPTY_ICONS: NonNullable<ToasterProps['icons']> = {};
 
 function orderToastsFromPosition(
   currentToasts: ToastProps[],
-  position: ToastPosition,
-  enableStacking: boolean
+  position: ToastPosition
 ): ToastProps[] {
-  if (enableStacking) {
-    return position === 'top-center'
-      ? currentToasts.slice().reverse()
-      : currentToasts;
-  }
   return position === 'top-center'
     ? currentToasts.slice().reverse()
     : currentToasts;
@@ -165,8 +159,8 @@ const ToasterUI: React.FC<
     [toastHeights, toastHeightsVersion, isExpanded]
   );
   const orderedToasts = React.useMemo(
-    () => orderToastsFromPosition(toasts, position, enableStacking),
-    [toasts, position, enableStacking]
+    () => orderToastsFromPosition(toasts, position),
+    [toasts, position]
   );
 
   const onDismiss = React.useCallback<


### PR DESCRIPTION
## Summary
- Center anchored to top:0 of full-screen container; flex centering didn't apply to absolute children → toasts rendered at top of screen.
- Center container now anchors at `top: '50%'` (zero-height, full-width). Position calc mirrors bottom-center plus `-frontHeight/2` shift so the front toast sits on the screen midline.
- Stacking, ordering, scaleX narrowing, entering/exiting translateY all mirror bottom-center for `center` position.

## Risk areas
- Absolute child `width: 100%` inside a `top: '50%'`/`left:0`/`right:0` container — verify full-width on iOS + Android.
- `centerShift` reads front toast height from `allToastHeights`; first frame before measurement falls back to `ESTIMATED_TOAST_HEIGHT`.
- Reversal direction in `getOrderedToastIds` / `orderToastsFromPosition` for center changed (was reversed when not stacking, now matches bottom-center).

## Test plan
- [ ] iOS: single center toast vertically centered.
- [ ] Android: single center toast vertically centered.
- [ ] Center stacked (3 toasts): front centered, behind toasts peek above, narrower scaleX.
- [ ] Center expanded: stack grows upward like bottom-center expanded.
- [ ] Top-center and bottom-center unchanged.