### PR TITLE
fix(android): elevate positioner above react-native-screens

### DIFF
--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, Pressable, Text, useColorScheme } from 'react-native';
+import { Pressable, Text, useColorScheme } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -62,7 +62,6 @@ const RootLayout: React.FC = () => {
           />
         </Stack>
         <Toaster
-          positionerStyle={Platform.OS === 'android' ? { elevation: 999 } : undefined}
           position={position}
           swipeToDismissDirection={swipeDirection}
           visibleToasts={visibleToasts}

--- a/src/positioner.tsx
+++ b/src/positioner.tsx
@@ -65,7 +65,7 @@ export const Positioner: React.FC<
         <Pressable style={outsidePressableStyle} onPress={handleOutsidePress} />
       )}
       <View
-        style={[containerStyle, insetValues, style]}
+        style={[containerStyle, androidElevationStyle, insetValues, style]}
         pointerEvents={
           Platform.OS === 'android' && !hasChildren ? 'none' : 'box-none'
         }
@@ -76,3 +76,8 @@ export const Positioner: React.FC<
     </>
   );
 };
+
+// Without elevation, the positioner can render behind sibling react-native-screens
+// surfaces (native-stack, bottom-tabs) on Android, hiding toasts entirely.
+const androidElevationStyle =
+  Platform.OS === 'android' ? { elevation: 9999 } : null;

--- a/src/positioner.tsx
+++ b/src/positioner.tsx
@@ -62,7 +62,10 @@ export const Positioner: React.FC<
     <>
       {/* Outside pressable area - positioned outside the toast stack */}
       {shouldAllowCollapse && (
-        <Pressable style={outsidePressableStyle} onPress={handleOutsidePress} />
+        <Pressable
+          style={[outsidePressableStyle, androidElevationStyle]}
+          onPress={handleOutsidePress}
+        />
       )}
       <View
         style={[containerStyle, androidElevationStyle, insetValues, style]}


### PR DESCRIPTION
## Summary

Fixes [#316](https://github.com/gunnartorfis/sonner-native-toasts/issues/316). Toasts were invisible on Android in apps using `react-native-screens`-based navigators (e.g. `@react-navigation/native-stack`, `bottom-tabs`) after v0.25.0.

**Root cause:** the `<Toaster>`'s Positioner is rendered as a sibling of the navigator. Without `elevation`, Android draws it *behind* the screen surface that `react-native-screens` creates, hiding the toast entirely. The example app already worked around this with `positionerStyle={{ elevation: 999 }}` ([688a1e7](https://github.com/gunnartorfis/sonner-native-toasts/commit/688a1e7)); this PR moves the workaround into the library so users don't have to.

**Verification:** reproduced with the minimal repro from the issue (no `positionerStyle`, `@react-navigation/native-stack`, Android emulator). Toast invisible before the patch; visible after. Without a navigator, the toast was visible in both — confirming it's the screens stacking, not animations / reduced-motion / store wiring.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (129 passed)
- [x] Manual: minimal repro from #316 — toast now visible on Android
- [x] Manual: example app still works after removing its redundant `positionerStyle` override
- [x] Manual: iOS unaffected (style is Android-only)