### PR TITLE
fix: getBoundingClientRect crash on RN 0.81 / Expo SDK 54

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -316,11 +316,17 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
       if (typeof toastRef.current.getBoundingClientRect === 'function') {
         const { height } = toastRef.current.getBoundingClientRect();
         toastStore.setToastHeight(id, height);
-      } else {
-        toastRef.current.measureInWindow((_x, _y, _w, height) => {
-          toastStore.setToastHeight(id, height);
-        });
+        return;
       }
+      let stale = false;
+      toastRef.current.measureInWindow((_x, _y, _w, height) => {
+        if (!stale) {
+          toastStore.setToastHeight(id, height);
+        }
+      });
+      return () => {
+        stale = true;
+      };
     }, [id, variant, title, description, jsx]);
 
     const defaultStyles = useDefaultStyles({

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -196,7 +196,9 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
     });
 
     const isDragging = React.useRef(false);
-    const toastRef = React.useRef<View & { getBoundingClientRect(): DOMRect }>(null);
+    const toastRef = React.useRef<
+      View & { getBoundingClientRect?: () => DOMRect }
+    >(null);
 
     const wiggleSharedValue = useSharedValue(1);
 
@@ -303,14 +305,22 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
       onForeground,
     });
 
-    // Synchronous layout read via New Architecture's getBoundingClientRect.
-    // Runs during commit so positions resolve in the same frame.
+    // Synchronous layout read via getBoundingClientRect when available
+    // (refs are ReactNativeElement by default from RN 0.83). Older New Arch
+    // versions (e.g. RN 0.81/Expo SDK 54) don't expose it on refs, so fall
+    // back to async measureInWindow.
     React.useLayoutEffect(() => {
       if (!toastRef.current) {
         return;
       }
-      const { height } = toastRef.current.getBoundingClientRect();
-      toastStore.setToastHeight(id, height);
+      if (typeof toastRef.current.getBoundingClientRect === 'function') {
+        const { height } = toastRef.current.getBoundingClientRect();
+        toastStore.setToastHeight(id, height);
+      } else {
+        toastRef.current.measureInWindow((_x, _y, _w, height) => {
+          toastStore.setToastHeight(id, height);
+        });
+      }
     }, [id, variant, title, description, jsx]);
 
     const defaultStyles = useDefaultStyles({


### PR DESCRIPTION
## Summary
- Fixes #317
- `getBoundingClientRect` only exists on refs when they are `ReactNativeElement` instances — default since RN 0.83. On RN 0.81/0.82 New Arch (Expo SDK 54), refs are `ReactFabricHostComponent` and the method is undefined → crash on every toast render
- Restore feature detection: use sync `getBoundingClientRect` when available, fall back to async `measureInWindow` otherwise

## Risk areas
- RN 0.83+ behavior unchanged — sync branch always taken there
- On RN ≤0.82 height lands a frame later (async), so stacking positions resolve slightly later — same as pre-b7e53f1 behavior

## Test plan
- [x] Repro app (Expo SDK 54, RN 0.81, New Arch): toast renders, no crash
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 136/136 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)