### PR TITLE
fix: widen peer dep ranges to floors (worklets, gesture-handler)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,12 +93,12 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": "^2.28.0",
+    "react-native-gesture-handler": ">=2.28.0",
     "react-native-reanimated": "^4.1.1",
     "react-native-safe-area-context": "^5.6.0",
     "react-native-screens": "^4.16.0",
     "react-native-svg": "^15.12.1",
-    "react-native-worklets": "^0.6.1 || ^0.7.0 || ^0.8.0"
+    "react-native-worklets": ">=0.6.1"
   },
   "workspaces": [
     "example",


### PR DESCRIPTION
## Problem

`npm install sonner-native` fails with `ERESOLVE` for users on `react-native-worklets@0.9.x` and `react-native-gesture-handler@3.0.0` (#315). The enumerated caret ranges (`^0.6.1 || ^0.7.0 || ^0.8.0`, `^2.28.0`) don't cover them, and every new worklets minor / RNGH major reintroduces the failure — a maintenance treadmill.

## Fix

Switch to `>=` floors:

```diff
-    "react-native-gesture-handler": "^2.28.0",
+    "react-native-gesture-handler": ">=2.28.0",
-    "react-native-worklets": "^0.6.1 || ^0.7.0 || ^0.8.0"
+    "react-native-worklets": ">=0.6.1"
```

## Why floors

- **worklets is reanimated's runtime.** `react-native-reanimated` itself declares `react-native-worklets: ">=0.7.0"`, so reanimated transitively governs the exact valid worklets version. sonner-native re-declaring a narrow range only *fights* that and produces false conflicts. A floor mirrors reanimated's own strategy and never needs touching again.
- **RNGH floor** covers 3.x/4.x. sonner-native uses only the modern `Gesture`/`GestureDetector` API (`src/gestures.tsx`), which is stable across RNGH 2.28→3.x.
- Other peers (reanimated, safe-area-context, screens, svg) stay on caret — they're 1.0+ and major-stable, where a major-break warning is still wanted.

If a future major genuinely breaks compat, we add an upper bound reactively from a bug report — strictly less work than republishing on every benign release.

Fixes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)