### PR TITLE
fix: free toastRefs entries when toasts are removed

### DIFF
--- a/src/__tests__/toast-store.test.ts
+++ b/src/__tests__/toast-store.test.ts
@@ -557,4 +557,35 @@ describe('ToastStore', () => {
       expect(subscriber2).toHaveBeenCalled();
     });
   });
+
+  describe('toastRefs cleanup', () => {
+    it('single dismiss frees the ref', () => {
+      const id = toastStore.addToast({ title: 'a', variant: 'info' as const });
+
+      expect(toastStore.getSnapshot().toastRefs[id]).toBeDefined();
+
+      toastStore.dismissToast(id);
+
+      expect(toastStore.getSnapshot().toastRefs[id]).toBeUndefined();
+    });
+
+    it('dismiss-all clears every ref', () => {
+      toastStore.addToast({ id: 'x', title: 'x', variant: 'info' as const });
+      toastStore.addToast({ id: 'y', title: 'y', variant: 'info' as const });
+
+      toastStore.dismissToast(undefined);
+
+      expect(Object.keys(toastStore.getSnapshot().toastRefs)).toHaveLength(0);
+    });
+
+    it('overflow trim frees the trimmed toast ref', () => {
+      toastStore.setConfig({ visibleToasts: 1 });
+
+      toastStore.addToast({ id: 'first', title: 'first', variant: 'info' as const });
+      toastStore.addToast({ id: 'second', title: 'second', variant: 'info' as const });
+
+      expect(toastStore.getSnapshot().toastRefs['first']).toBeUndefined();
+      expect(toastStore.getSnapshot().toastRefs['second']).toBeDefined();
+    });
+  });
 });

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -299,6 +299,7 @@ class ToastStore {
         if (removedToast) {
           this.clearTimer(removedToast.id);
           newIndex.delete(removedToast.id);
+          delete newToastRefs[removedToast.id];
           if (removedToast.id in updatedHeights) {
             delete updatedHeights[removedToast.id];
             heightsChanged = true;
@@ -362,6 +363,7 @@ class ToastStore {
         toasts: [],
         toastsById: new Map(),
         toastsCounter: 1,
+        toastRefs: {},
         toastTimers: {},
         toastHeights: {},
         toastHeightsVersion: this.state.toastHeightsVersion + 1,
@@ -384,6 +386,9 @@ class ToastStore {
     const updatedHeights = { ...this.state.toastHeights };
     delete updatedHeights[id];
 
+    const updatedRefs = { ...this.state.toastRefs };
+    delete updatedRefs[id];
+
     const shouldAutoCollapse =
       filteredToasts.length <= 1 && this.state.isExpanded;
 
@@ -394,6 +399,7 @@ class ToastStore {
       ...this.state,
       toasts: filteredToasts,
       toastsById: updatedIndex,
+      toastRefs: updatedRefs,
       toastHeights: updatedHeights,
       toastHeightsVersion: this.state.toastHeightsVersion + 1,
       isExpanded: shouldAutoCollapse ? false : this.state.isExpanded,


### PR DESCRIPTION
## Summary
- `ToastStore.toastRefs` (`Record<id, RefObject>`) gained an entry on every new toast id but **no path ever removed one** — a slow unbounded memory leak, worst with custom string ids (which never recycle) and apps that never dismiss-all.
- Free the ref alongside the existing per-toast cleanup in all three removal paths:
  - **Overflow trim** — `delete newToastRefs[removedToast.id]` when the stack exceeds `visibleToasts`.
  - **Single dismiss** — clone `toastRefs`, delete the id, assign into new state (mirrors the existing `updatedHeights` handling).
  - **Dismiss-all** — reset `toastRefs: {}` in the state reset.
- Added 3 regression tests (`toastRefs cleanup`) covering each path.

## Risk areas
- Refs are now deleted in lock-step with `toastsById`. Verified no consumer reads a ref for a removed toast: `wiggleToast` early-returns when the id is absent from `toastsById`, and `getToastRef` is only called from `toaster.tsx` for toasts currently rendered. No behavioral change for live toasts.
- Pure cleanup — no change to toast lifecycle, timers, or rendering.

## Test plan
- [x] `pnpm test` — 139 passed, 8 suites (incl. 3 new `toastRefs cleanup` tests)
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm lint` — exit 0