### PR TITLE
test: re-enable areToastsEqual comparator test

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,7 @@
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/lib/",
-      "<rootDir>/example/",
-      "src/__tests__/toast-comparator.test.tsx"
+      "<rootDir>/example/"
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",

--- a/src/__tests__/toast-comparator.test.tsx
+++ b/src/__tests__/toast-comparator.test.tsx
@@ -215,6 +215,30 @@ describe('areToastsEqual', () => {
     expect(areToastsEqual(toast1, toast2)).toBe(true);
   });
 
+  it('should return true when cancel onClick differs but label is the same', () => {
+    const toast1: ToastProps = {
+      ...base,
+      id: 1,
+      title: 'Toast 1',
+      variant: 'success' as const,
+      cancel: { label: 'Dismiss', onClick: () => {} },
+      index: 0,
+      numberOfToasts: 1,
+    };
+
+    const toast2: ToastProps = {
+      ...base,
+      id: 1,
+      title: 'Toast 1',
+      variant: 'success' as const,
+      cancel: { label: 'Dismiss', onClick: () => console.log('different handler') },
+      index: 0,
+      numberOfToasts: 1,
+    };
+
+    expect(areToastsEqual(toast1, toast2)).toBe(true);
+  });
+
   it('should return false when cancel labels are different', () => {
     const toast1: ToastProps = {
       ...base,

--- a/src/__tests__/toast-comparator.test.tsx
+++ b/src/__tests__/toast-comparator.test.tsx
@@ -1,5 +1,5 @@
 import { View } from 'react-native';
-import type { ToastProps } from '../types'; // Adjust the import path Adjust the import path
+import type { ToastProps } from '../types';
 import { areToastsEqual } from '../toast-comparator';
 
 // Mock helper function to simulate a click handler
@@ -184,6 +184,30 @@ describe('areToastsEqual', () => {
       variant: 'success',
       action: mockReactNode,
       cancel: mockReactNode,
+      index: 0,
+      numberOfToasts: 1,
+    };
+
+    expect(areToastsEqual(toast1, toast2)).toBe(true);
+  });
+
+  it('should return true when action onClick differs but label is the same', () => {
+    const toast1: ToastProps = {
+      ...base,
+      id: 1,
+      title: 'Toast 1',
+      variant: 'success' as const,
+      action: { label: 'Retry', onClick: () => {} },
+      index: 0,
+      numberOfToasts: 1,
+    };
+
+    const toast2: ToastProps = {
+      ...base,
+      id: 1,
+      title: 'Toast 1',
+      variant: 'success' as const,
+      action: { label: 'Retry', onClick: () => console.log('different handler') },
       index: 0,
       numberOfToasts: 1,
     };


### PR DESCRIPTION
## Summary

Restores test coverage for `areToastsEqual` (`src/toast-comparator.ts`), which was **silently excluded** from Jest via `testPathIgnorePatterns` in `package.json`. The comparator decides whether an updated toast changed enough to trigger the wiggle animation (`autoWiggleOnUpdate: 'toast-change'`); it had **zero active test coverage**, so a regression (e.g. forgetting to compare a new field) would pass CI unnoticed.

## Changes

- **`package.json`** — remove `src/__tests__/toast-comparator.test.tsx` from `jest.testPathIgnorePatterns` so the suite runs again.
- **`src/__tests__/toast-comparator.test.tsx`** — clean up a malformed leftover comment on line 2; add one guard test asserting that two toasts with the same `action.label` but different `onClick` handlers compare equal (documents the label-only comparison in `areActionsEqual`).

## Findings

The test passed on first run with **no changes to `src/toast-comparator.ts`** — the comparator has no gap; the test was simply disabled for unrecorded historical reasons. The implementation is untouched.

## Verification

- `pnpm test src/__tests__/toast-comparator.test.tsx` → 10 passed
- `pnpm test` (full) → 149 passed / 9 suites
- `pnpm typecheck` → exit 0
- `pnpm lint` → exit 0

## Maintenance note

Any new `ToastProps` field that should influence "did the toast meaningfully change?" must be added to **both** `areToastsEqual` and this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)