### PR TITLE
fix: use useWindowDimensions so swipe/stack width tracks rotation

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -17,6 +17,7 @@ jest.mock('react-native', () => {
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
     },
+    useWindowDimensions: jest.fn(() => ({ width: 375, height: 812 })),
     View,
     Text,
     Pressable,

--- a/src/gestures.tsx
+++ b/src/gestures.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dimensions, Platform, type ViewStyle } from 'react-native';
+import { Platform, useWindowDimensions, type ViewStyle } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
@@ -14,7 +14,6 @@ import { useToastContext } from './context';
 import { easeInOutCircFn } from './easings';
 import type { ToastPosition, ToastProps } from './types';
 
-const { width: WINDOW_WIDTH } = Dimensions.get('window');
 
 type ToastSwipeHandlerProps = Pick<
   ToastProps,
@@ -44,6 +43,7 @@ export const ToastSwipeHandler: React.FC<
   position: positionProps,
   onPress,
 }) => {
+  const { width: windowWidth } = useWindowDimensions();
   const translate = useSharedValue(0);
   const {
     swipeToDismissDirection: direction,
@@ -93,7 +93,7 @@ export const ToastSwipeHandler: React.FC<
       }
 
       if (direction === 'left') {
-        const threshold = -WINDOW_WIDTH * 0.25;
+        const threshold = -windowWidth * 0.25;
         const shouldDismiss = translate.value < threshold;
 
         if (Math.abs(translate.value) < 16) {
@@ -105,7 +105,7 @@ export const ToastSwipeHandler: React.FC<
 
         if (shouldDismiss) {
           translate.value = withTiming(
-            -WINDOW_WIDTH,
+            -windowWidth,
             {
               easing: Easing.inOut(Easing.ease),
             },
@@ -137,7 +137,7 @@ export const ToastSwipeHandler: React.FC<
           });
         } else if (shouldDismiss) {
           translate.value = withTiming(
-            -WINDOW_WIDTH,
+            -windowWidth,
             {
               easing: Easing.inOut(Easing.ease),
             },
@@ -182,13 +182,13 @@ export const ToastSwipeHandler: React.FC<
     } else {
       aStyle.opacity = interpolate(
         translate.value,
-        [0, direction === 'left' ? -WINDOW_WIDTH : -60],
+        [0, direction === 'left' ? -windowWidth : -60],
         [1, 0]
       );
     }
 
     return aStyle;
-  }, [direction, translate]);
+  }, [direction, translate, windowWidth]);
 
   return (
     <GestureDetector gesture={Gesture.Race(tap, pan)}>

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {
   ActivityIndicator,
-  Dimensions,
   Pressable,
   Text,
   View,
+  useWindowDimensions,
   type ViewProps,
 } from 'react-native';
 import Animated, {
@@ -209,7 +209,7 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
     }, [wiggleSharedValue]);
 
     // ScaleX: visual narrowing avoids layout-width changes that cause text rewrap
-    const screenWidth = Dimensions.get('window').width;
+    const { width: screenWidth } = useWindowDimensions();
     const stackScaleX = useDerivedValue(() => {
       'worklet';
       if (!enableStacking || numberOfToasts <= 1 || isExpanded) {
@@ -371,7 +371,7 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
           if (
             isPressNearCloseButton({
               x,
-              viewWidth: Dimensions.get('window').width,
+              viewWidth: screenWidth,
             })
           ) {
             // On Android, the RNGH Tap gesture intercepts the touch before
@@ -386,7 +386,7 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
         }
         onPress?.();
       },
-      [position, positionCtx, enableStacking, numberOfToasts, toggleExpand, onPress, isExpanded, closeButton, dismissible, onDismiss, id]
+      [position, positionCtx, enableStacking, numberOfToasts, toggleExpand, onPress, isExpanded, closeButton, dismissible, onDismiss, id, screenWidth]
     );
 
     const toastSwipeHandlerProps = React.useMemo(


### PR DESCRIPTION
## What

Read the window width reactively via React Native's `useWindowDimensions()` hook instead of the non-reactive `Dimensions.get('window')`.

## Why

The library read screen width in three places that never reacted to orientation / size changes:

- `src/gestures.tsx` captured `WINDOW_WIDTH` **once at module load** — stale after any rotation, fold/unfold, or split-screen resize.
- `src/toast.tsx` (×2) called `Dimensions.get('window')` during render/handler, which is also non-reactive (a dimension change doesn't trigger a re-render).

That stale width feeds the left-swipe dismiss threshold (`width * 0.25`), the swipe-away animation target (`-width`), the opacity interpolation, and the stacking scale-X narrowing. On tablets, foldables, and any app that rotates, these become mis-calibrated after the first orientation change.

## Changes

- `src/gestures.tsx`: drop module-level `WINDOW_WIDTH`; read `windowWidth` via `useWindowDimensions()` in the component body; add it to the `useAnimatedStyle` dependency array.
- `src/toast.tsx`: read `screenWidth` via `useWindowDimensions()`; reuse it in `onSwipePress` and add it to that `useCallback` dependency array.
- `src/__tests__/setup.ts`: mock `useWindowDimensions` (consistent with the existing `Dimensions` mock, `{ width: 375, height: 812 }`).

No swipe/scale formula constants were changed — only where the width comes from.

## Verification

- `pnpm typecheck` → exit 0
- `pnpm lint` → exit 0
- `pnpm test` → 150 passed / 9 suites

## Notes

This is a device-behavioral fix (rotation/fold/split-screen) the current unit suite can't exercise — the green suite confirms no regression. A follow-up component test that mounts `ToastSwipeHandler`, changes the mocked dimensions, and asserts the threshold/animation target track the new width is deferred to a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
