### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@
 applied to the latest published minor release only. If you are on an older
 version, upgrade to the latest before reporting.
 
-| Version  | Supported          |
-| -------- | ------------------ |
-| 0.26.x   | :white_check_mark: |
-| < 0.26   | :x:                |
+| Version      | Supported          |
+| ------------ | ------------------ |
+| latest minor | :white_check_mark: |
+| older minors | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+`sonner-native` is pre-1.0 and ships frequent releases. Security fixes are
+applied to the latest published minor release only. If you are on an older
+version, upgrade to the latest before reporting.
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| 0.26.x   | :white_check_mark: |
+| < 0.26   | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.
+
+Instead, report them privately through GitHub's
+[Security Advisories](https://github.com/gunnartorfis/sonner-native/security/advisories/new)
+("Report a vulnerability"). If you cannot use that, email the maintainer at
+**gunnartorfis@gmail.com**.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce or a proof of concept.
+- Affected version(s) and relevant environment (React Native / Expo version,
+  platform).
+- Any suggested fix or mitigation.
+
+### What to expect
+
+- **Acknowledgement:** within 7 days of your report.
+- **Updates:** at least every 14 days while the report is being investigated.
+- **Resolution:** if accepted, a fix is prioritized and released in a new
+  version, with a published advisory crediting you (unless you prefer to remain
+  anonymous). If declined, you'll receive an explanation of why.
+
+Thank you for helping keep `sonner-native` and its users safe.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` at the repo root defining the project's security policy.
- Supported versions reflect the pre-1.0 release model: only the latest minor (`0.26.x`) receives security fixes.
- Reporting routes through GitHub private Security Advisories (already enabled on this repo), with the maintainer's email as a fallback.
- Documents expected response timelines (7-day ack, 14-day update cadence) and accept/decline outcomes incl. advisory credit.

## Risk areas
- Docs-only change; no code or build impact.
- Verify the supported-versions table stays accurate as releases progress past `0.26.x`.

## Test plan
- [ ] Confirm `SECURITY.md` renders correctly on GitHub and appears in the repo's Security tab.
- [ ] Confirm the "Report a vulnerability" advisory link resolves.