### PR TITLE
fix: prevent spread from overwriting Toaster list key

### DIFF
--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -221,6 +221,7 @@ const ToasterUI: React.FC<
             .map((toastToRender, index) => {
               const ToastToRender = (
                 <Toast
+                  key={toastToRender.id}
                   {...props}
                   {...toastToRender}
                   parentStyle={props.style}
@@ -229,7 +230,6 @@ const ToasterUI: React.FC<
                   onAutoClose={onAutoClose}
                   index={index}
                   ref={toastStore.getToastRef(toastToRender.id)}
-                  key={toastToRender.id}
                   numberOfToasts={toastsForPosition.length}
                   orderedToastIds={orderedToastIds}
                 />


### PR DESCRIPTION
Moves the `key` prop above the `{...props}` / `{...toastToRender}` spreads in `<Toaster>`'s list render, so a spread can never overwrite it and break React's list reconciliation.

Caught by react-doctor (`react-doctor/jsx-key`) — the only error-severity finding in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
