### PR TITLE
refactor: drop unused internal exports

### DIFF
--- a/src/animations.ts
+++ b/src/animations.ts
@@ -79,7 +79,7 @@ type GetToastAnimationParams = {
   stackGap?: number;
 };
 
-export const getToastEntering = ({ position }: GetToastAnimationParams) => {
+const getToastEntering = ({ position }: GetToastAnimationParams) => {
   'worklet';
 
   const animations = {
@@ -114,7 +114,7 @@ export const getToastEntering = ({ position }: GetToastAnimationParams) => {
   };
 };
 
-export const getToastExiting = ({
+const getToastExiting = ({
   position,
   isHiddenByLimit,
   numberOfToasts,

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -612,7 +612,7 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
 
 Toast.displayName = 'Toast';
 
-export const ToastIcon: React.FC<
+const ToastIcon: React.FC<
   Pick<ToastProps, 'variant'> & {
     invert: boolean;
     richColors: boolean;


### PR DESCRIPTION
Removes three unused internal `export`s flagged by react-doctor (`deslop/unused-export`). Each is used only within its own module and is **not** part of the public API — none are re-exported from `src/index.tsx`, and the package `exports` map exposes only `.` (not `./src/*`), so they were never an importable supported path:

- `getToastEntering` / `getToastExiting` in `src/animations.ts`
- `ToastIcon` in `src/toast.tsx`

> **Scope note:** this PR originally also adopted React 19 `use()` / ref-as-prop APIs. That was dropped to preserve React 18.3 support (a valid `react-native-reanimated@4` / RN 0.78 target — RN 0.78 ships React 18.3.1). The optional `react-doctor/no-react19-deprecated-apis` hint is instead suppressed in the config PR (#337); `useContext` / `forwardRef` are kept since neither is deprecated in React 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
