### PR TITLE
chore: harden pnpm supply chain and Babel runtime helpers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,14 @@ module.exports = {
     },
     {
       include: /\/node_modules\//,
-      presets: ['module:@react-native/babel-preset'],
+      presets: [
+        // Pin enableBabelRuntime so Babel helpers are imported once from
+        // @babel/runtime instead of duplicated per file (smaller JS bundle).
+        [
+          'module:@react-native/babel-preset',
+          { enableBabelRuntime: '^7.29.0' },
+        ],
+      ],
     },
   ],
 };

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - 'example'
   - 'docs'
+
+# Supply-chain hardening (react-doctor/require-pnpm-hardening)
+# Delay installs of freshly published versions so malware has time to be caught.
+minimumReleaseAge: 10080 # 7 days, in minutes
+# Reject packages whose trust signals (provenance/signatures) weaken between updates.
+trustPolicy: no-downgrade


### PR DESCRIPTION
Two independent build / supply-chain hardening tweaks flagged by react-doctor:

- **pnpm-workspace.yaml**: add `minimumReleaseAge: 10080` (7 days) and `trustPolicy: no-downgrade`, so freshly published or trust-downgraded packages aren't installed before they've had time to be vetted (`react-doctor/require-pnpm-hardening`). The committed lockfile still installs cleanly (verified with `pnpm install --frozen-lockfile`).
- **babel.config.js**: pin `enableBabelRuntime: '^7.29.0'` on `@react-native/babel-preset` so Babel helpers are imported once from `@babel/runtime` instead of duplicated per file (`react-doctor/rn-no-metro-babel-runtime-version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
