### PR TITLE
chore: add react-doctor config, CI workflow, and doctor script

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,50 @@
+# React Doctor — finds security, performance, correctness, accessibility,
+# bundle-size, and architecture issues in React codebases.
+#
+# Docs: https://www.react.doctor/ci
+# Source: https://github.com/millionco/react-doctor
+
+name: React Doctor
+
+on:
+  # Scans the PR's changed files and posts a sticky summary comment listing only the new issues introduced relative to the merge base of the target branch.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Scans `main` on every push to track the health-score trend and catch regressions that slipped past PR review.
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+# Cancels any in-flight scan for the same PR (or branch, on push) the moment a new commit arrives, so reviewers only ever see the latest run.
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: millionco/react-doctor@v2
+        # Advisory by default: React Doctor reports findings on every PR — a
+        # sticky summary comment, inline review comments, and a commit status
+        # with the health score — but never fails the check, so it won't red-X
+        # a teammate's PR on day one. When your team trusts the signal, graduate
+        # the gate: uncomment the block below and set blocking to "error" (fail
+        # on new error-severity findings) or "warning" (fail on any finding).
+        # Full reference: https://www.react.doctor/ci
+        # with:
+        #   blocking: error          # Gate level: "none" (advisory, the default) | "warning" | "error"
+        #   scope: full              # On PRs, scan the whole project instead of just changed files
+        #   comment: false           # Disable the sticky PR summary comment
+        #   review-comments: false   # Disable inline review comments on changed lines
+        #   commit-status: false     # Disable the commit status (score + counts, links to the run)
+        #   version: "0.4.0"         # Pin to a specific react-doctor version instead of "latest"
+        #   directory: apps/web      # Scan a sub-directory (default: ".")
+        #   project: "web,admin"     # In a monorepo, scan specific workspace project(s)

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Full history so React Doctor can find the PR merge base and report
+          # only newly-introduced issues (diff scans need it; depth-1 loses it).
+          fetch-depth: 0
 
       - uses: millionco/react-doctor@v2
         # Advisory by default: React Doctor reports findings on every PR — a

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://react.doctor/schema/config.json",
+  "rules": {
+    "react-doctor/no-react19-deprecated-apis": "off"
+  },
+  "ignore": {
+    "overrides": [
+      {
+        "files": ["src/toast-store.ts"],
+        "rules": ["react-doctor/async-defer-await"]
+      },
+      {
+        "files": ["package.json"],
+        "rules": ["deslop/unused-dev-dependency"]
+      },
+      {
+        "files": ["**/components/toast-demo.*.tsx"],
+        "rules": [
+          "react-doctor/no-giant-component",
+          "react-doctor/no-inline-exhaustive-style",
+          "react-doctor/rendering-hydration-mismatch-time",
+          "react-doctor/rn-prefer-expo-image",
+          "deslop/unused-export"
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli lib",
     "prepare": "bob build",
-    "release": "release-it"
+    "release": "release-it",
+    "doctor": "npx react-doctor@latest"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Adopts react-doctor as the project's React health gate and pins the config that makes a clean run score 100/100.

- **doctor.config.json**
  - `react-doctor/no-react19-deprecated-apis` — **off** (project-wide). The library intentionally keeps `useContext` / `forwardRef` to preserve React 18.3 support (a valid `react-native-reanimated@4` / RN 0.78 target). Neither API is deprecated in React 19, so this is an optional migration hint, not a real issue.
  - `async-defer-await` on `toast-store.ts` — the post-`await` guard re-checks the toast still exists after the promise resolves (intentional).
  - `unused-dev-dependency` on `package.json` — `@release-it/conventional-changelog` is used via release-it's plugin config, invisible to a static scan.
  - demo-only rules on `example/components/toast-demo.*` + a platform-suffix (`.android`/`.ios`) `unused-export` false positive.
- **.github/workflows/react-doctor.yml** — advisory PR + push scan (won't fail a check until you opt in).
- **`doctor`** package script — `npx react-doctor@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
