### PR TITLE
fix: place default-position toasts in the configured container

### DIFF
--- a/src/__tests__/toaster.test.tsx
+++ b/src/__tests__/toaster.test.tsx
@@ -1,8 +1,10 @@
 import { act } from 'react';
 import TestRenderer from 'react-test-renderer';
+import { Positioner } from '../positioner';
 import { Toaster } from '../toaster';
 import { toast } from '../toast-fns';
 import { toastStore } from '../toast-store';
+import type { ToastPosition } from '../types';
 
 const resetStore = () => {
   toastStore['state'] = {
@@ -69,6 +71,93 @@ describe('Toaster (render)', () => {
     const json = textOf(renderer);
     expect(json).toContain('Title here');
     expect(json).toContain('Some description');
+  });
+
+  describe('position bucketing', () => {
+    const findPositioner = (
+      renderer: TestRenderer.ReactTestRenderer,
+      position: ToastPosition
+    ) => {
+      const match = renderer.root
+        .findAllByType(Positioner)
+        .find((positioner) => positioner.props.position === position);
+      if (!match) {
+        throw new Error(`No Positioner rendered for position ${position}`);
+      }
+      return match;
+    };
+
+    const positionerContains = (
+      positioner: TestRenderer.ReactTestInstance,
+      title: string
+    ): boolean => {
+      return (
+        positioner.findAll((node) => node.props?.children === title).length > 0
+      );
+    };
+
+    it('keeps position-less toasts in the Toaster default container when another toast uses an explicit position', () => {
+      let renderer!: TestRenderer.ReactTestRenderer;
+      act(() => {
+        renderer = TestRenderer.create(<Toaster position="bottom-center" />);
+      });
+      act(() => {
+        toast('plain');
+        toast('pinned', { position: 'top-center' });
+      });
+
+      expect(
+        positionerContains(findPositioner(renderer, 'bottom-center'), 'plain')
+      ).toBe(true);
+      expect(
+        positionerContains(findPositioner(renderer, 'top-center'), 'pinned')
+      ).toBe(true);
+      expect(
+        positionerContains(findPositioner(renderer, 'top-center'), 'plain')
+      ).toBe(false);
+    });
+
+    it('keeps position-less toasts in a center default container alongside an explicit bottom-center toast', () => {
+      let renderer!: TestRenderer.ReactTestRenderer;
+      act(() => {
+        renderer = TestRenderer.create(<Toaster position="center" />);
+      });
+      act(() => {
+        toast('floaty');
+        toast('grounded', { position: 'bottom-center' });
+      });
+
+      expect(
+        positionerContains(findPositioner(renderer, 'center'), 'floaty')
+      ).toBe(true);
+      expect(
+        positionerContains(
+          findPositioner(renderer, 'bottom-center'),
+          'grounded'
+        )
+      ).toBe(true);
+      expect(
+        positionerContains(findPositioner(renderer, 'bottom-center'), 'floaty')
+      ).toBe(false);
+    });
+
+    it('orders a top-center container newest-first even when the Toaster default is bottom-center', () => {
+      let renderer!: TestRenderer.ReactTestRenderer;
+      act(() => {
+        renderer = TestRenderer.create(<Toaster position="bottom-center" />);
+      });
+      act(() => {
+        toast('a', { position: 'top-center' });
+        toast('b', { position: 'top-center' });
+      });
+
+      const topPositioner = findPositioner(renderer, 'top-center');
+      const titlesInRenderOrder = topPositioner
+        .findAll((node) => node.props?.children === 'a' || node.props?.children === 'b')
+        .map((node) => node.props.children);
+      // top-center renders newest first (same as a top-center default Toaster)
+      expect(titlesInRenderOrder).toEqual(['b', 'a']);
+    });
   });
 
   it('removes the toast after dismiss', () => {

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -168,11 +168,6 @@ const ToasterUI: React.FC<
     }),
     [toastHeights, toastHeightsVersion, isExpanded]
   );
-  const orderedToasts = React.useMemo(
-    () => orderToastsFromPosition(toasts, position),
-    [toasts, position]
-  );
-
   const onDismiss = React.useCallback<
     NonNullable<React.ComponentProps<typeof Toast>['onDismiss']>
   >((id) => {
@@ -200,11 +195,13 @@ const ToasterUI: React.FC<
   return (
     <ToastContext.Provider value={value}>
       <DynamicToastContext.Provider value={dynamicValue}>
-      {possiblePositions.map((currentPosition, positionIndex) => {
-        const toastsForPosition = orderedToasts.filter(
-          (possibleToast) =>
-            (!possibleToast.position && positionIndex === 0) ||
-            possibleToast.position === currentPosition
+      {possiblePositions.map((currentPosition) => {
+        const toastsForPosition = orderToastsFromPosition(
+          toasts.filter(
+            (possibleToast) =>
+              (possibleToast.position ?? position) === currentPosition
+          ),
+          currentPosition
         );
         const orderedToastIds = getOrderedToastIds(
           toastsForPosition,


### PR DESCRIPTION
Fixes #339

## Summary
- Position-less toasts now render in the `<Toaster position=...>` default container instead of whichever position sorts first in the internal position list. Previously, `<Toaster position="bottom-center" />` plus a single `toast('x', { position: 'top-center' })` pulled every default toast to the top of the screen.
- Toast ordering is now applied **per container** (newest-first for `top-center` containers) instead of reversing the global list by the default position — fixes wrong `index`/stacking offsets/zIndex for minority-position toasts.

## Test evidence
TDD (red-green): 3 new render tests in `src/__tests__/toaster.test.tsx` — default-container bucketing under `bottom-center` and `center` defaults with mixed explicit positions, and newest-first ordering for a non-default `top-center` container. Both new behaviors reproduced as failures before the fix.

- `pnpm test`: 158 passed (10 suites)
- `pnpm typecheck`: clean
- `pnpm lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)