### PR TITLE
fix: cancel running timer when a toast updates to infinite duration

### DIFF
--- a/src/__tests__/toast-store.test.ts
+++ b/src/__tests__/toast-store.test.ts
@@ -1,3 +1,4 @@
+import { ENTERING_ANIMATION_DURATION } from '../animations';
 import { toastStore } from '../toast-store';
 import type { ToastRef } from '../types';
 import type React from 'react';
@@ -308,6 +309,29 @@ describe('ToastStore', () => {
       expect(state.toastTimers[id2]).toBeDefined();
       // Note: With fake timers, the new setTimeout is created but isPaused state
       // depends on the implementation details. Let's just verify timers exist.
+    });
+
+    it('clears the running timer when a toast is updated to duration: Infinity', () => {
+      const id = toastStore.addToast({ id: 'pin-me', title: 'Uploading', duration: 5000, variant: 'info' as const });
+
+      toastStore.addToast({ id: 'pin-me', title: 'Uploading', duration: Infinity, variant: 'info' as const });
+
+      jest.advanceTimersByTime(60000);
+
+      const state = toastStore.getSnapshot();
+      expect(state.toastsById.has(id)).toBe(true);
+      expect(state.toastTimers[id]).toBeUndefined();
+    });
+
+    it('still auto-dismisses when updated from Infinity to a finite duration', () => {
+      const id = toastStore.addToast({ id: 'unpin-me', title: 'Pinned', duration: Infinity, variant: 'info' as const });
+
+      toastStore.addToast({ id: 'unpin-me', title: 'Pinned', duration: 2000, variant: 'info' as const });
+
+      jest.advanceTimersByTime(ENTERING_ANIMATION_DURATION + 2000 + 1);
+
+      const state = toastStore.getSnapshot();
+      expect(state.toastsById.has(id)).toBe(false);
     });
 
     it('should enforce minimum 1 second when resuming timer', () => {

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -84,12 +84,12 @@ class ToastStore {
     duration: number;
     onComplete: () => void;
   }) => {
+    this.clearTimer(id);
+
     // Don't start timer for infinite duration
     if (duration === Infinity) {
       return;
     }
-
-    this.clearTimer(id);
 
     const timeout = setTimeout(() => {
       onComplete();
@@ -259,7 +259,7 @@ class ToastStore {
         return currentToast;
       });
 
-      // Restart timer if duration changed
+      // Restart the auto-dismiss timer on every non-promise update
       if (!newToast.promiseOptions) {
         this.startTimer({
           id,


### PR DESCRIPTION
Fixes #340

## Summary
`toastStore.startTimer` returned early for `duration: Infinity` **before** clearing the existing timer, so updating a visible toast to `Infinity` — the idiomatic way to pin it (`toast('Uploading…', { id, duration: Infinity })`) — left the old finite timer running and the toast still auto-dismissed. The fix moves `clearTimer(id)` above the Infinity guard; the JS-side special-casing of Infinity (no native timer) is unchanged.

Also corrects the stale `// Restart timer if duration changed` comment (the timer restarts on every non-promise update by design).

## Test evidence
TDD (red-green): 2 new tests in `src/__tests__/toast-store.test.ts` — the pin scenario reproduced as a failure before the fix (toast dismissed at 60s despite the Infinity update), plus a regression guard for the reverse direction (Infinity → finite still auto-dismisses).

- `pnpm test`: 160 passed (10 suites)
- `pnpm typecheck`: clean
- `pnpm lint`: clean

## Manual test plan (example app)
Run from this branch: `git checkout fix/infinity-duration-update && pnpm install && pnpm example start`, then `i` or `a`.

**Temporary triggers** — add two buttons to `example/app/(tabs)/(home)/index.tsx`:
```tsx
<Button
  title="1: toast (5s)"
  onPress={() => toast('Uploading…', { id: 'pin-demo', duration: 5000 })}
/>
<Button
  title="2: pin it (Infinity)"
  onPress={() => toast('Uploading…', { id: 'pin-demo', duration: Infinity })}
/>
```

1. **The bug**: press **1**, then within ~3s press **2**. Wait 10+ seconds → the toast must STAY on screen indefinitely. ❌ Before this fix it disappeared ~5s after the first press. Dismiss it manually (swipe) when done.
2. **Reverse direction**: press **2** first (fresh toast, pinned — verify it outlives 10s), then press **1** → it must auto-dismiss ~5s later.
3. **Regression**: fire a few normal toasts from the existing buttons → they still auto-dismiss on their usual schedule; promise toasts (if the demo has one) still resolve and dismiss normally.

Revert the temporary buttons when done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)