### PR TITLE
chore: move onlyBuiltDependencies and overrides to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,17 +108,6 @@
     "docs"
   ],
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@evilmartians/lefthook",
-      "core-js",
-      "core-js-pure",
-      "unrs-resolver"
-    ],
-    "overrides": {
-      "@expo/log-box": "55.0.10"
-    }
-  },
   "jest": {
     "preset": "react-native",
     "setupFilesAfterEnv": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,13 @@ packages:
 minimumReleaseAge: 10080 # 7 days, in minutes
 # Reject packages whose trust signals (provenance/signatures) weaken between updates.
 trustPolicy: no-downgrade
+
+# Only these dependencies may run install-time build scripts.
+onlyBuiltDependencies:
+  - '@evilmartians/lefthook'
+  - core-js
+  - core-js-pure
+  - unrs-resolver
+
+overrides:
+  '@expo/log-box': 55.0.10


### PR DESCRIPTION
Fixes #341

## Summary
pnpm 10 no longer reads the `pnpm` field in `package.json` — every install printed *"The 'pnpm' field … ignored: 'onlyBuiltDependencies', 'overrides'"*, meaning the `@expo/log-box` pin and the build-script allowlist were silently dead and would be dropped on the next lockfile regeneration. Both keys now live in `pnpm-workspace.yaml` alongside the already-migrated `minimumReleaseAge`/`trustPolicy`; the `pnpm` field is deleted.

## Test evidence
- `pnpm install`: ignored-field warning **gone**; no build-script prompts; lockfile unchanged (override was already encoded — now sourced from the supported location)
- `grep -c '"pnpm"' package.json` → 0
- `@expo/log-box` still resolved to `55.0.10` in `pnpm-lock.yaml`
- `pnpm test` (160), `pnpm typecheck`, `pnpm lint`: all green

## Manual test plan (config-only change — verify, no app run needed)
1. Check out this branch, run `pnpm install` → confirm the *"'pnpm' field in package.json is no longer read"* warning no longer appears (it appears on every install on `main`).
2. `grep -n '@expo/log-box' pnpm-lock.yaml` → pinned to `55.0.10`.
3. CI on this PR green (installs use `--frozen-lockfile`, proving the lockfile is consistent).
4. Optional smoke: `pnpm example start` boots normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)