### PR TITLE
perf: memoize Toast and stabilize per-position props

### DIFF
--- a/example/components/toast-demo.ios.tsx
+++ b/example/components/toast-demo.ios.tsx
@@ -60,9 +60,7 @@ const ToastDemo: React.FC = () => {
           >
             <SwiftUIText modifiers={[tag('top-center')]}>Top</SwiftUIText>
             <SwiftUIText modifiers={[tag('center')]}>Center</SwiftUIText>
-            <SwiftUIText modifiers={[tag('bottom-center')]}>
-              Bottom
-            </SwiftUIText>
+            <SwiftUIText modifiers={[tag('bottom-center')]}>Bottom</SwiftUIText>
           </Picker>
           <Picker
             label="Theme"
@@ -77,9 +75,7 @@ const ToastDemo: React.FC = () => {
           <Picker
             label="Swipe Direction"
             selection={swipeDirection}
-            onSelectionChange={(v) =>
-              setParam('swipeDirection', v as string)
-            }
+            onSelectionChange={(v) => setParam('swipeDirection', v as string)}
             modifiers={[pickerStyle('menu')]}
           >
             <SwiftUIText modifiers={[tag('up')]}>Up</SwiftUIText>
@@ -100,9 +96,7 @@ const ToastDemo: React.FC = () => {
           <Picker
             label="Visible Toasts"
             selection={String(visibleToasts)}
-            onSelectionChange={(v) =>
-              setParam('visibleToasts', v as string)
-            }
+            onSelectionChange={(v) => setParam('visibleToasts', v as string)}
             modifiers={[pickerStyle('menu')]}
           >
             {['1', '2', '3', '4', '5'].map((n) => (
@@ -188,10 +182,7 @@ const ToastDemo: React.FC = () => {
             label="Show basic toast"
           />
           <SwiftUIButton
-            modifiers={[
-              buttonStyle('bordered'),
-              disabledModifier(!toastId),
-            ]}
+            modifiers={[buttonStyle('bordered'), disabledModifier(!toastId)]}
             onPress={() => {
               toast.dismiss(toastId!);
               setToastId(null);
@@ -366,8 +357,7 @@ const ToastDemo: React.FC = () => {
                 toast.info('Second toast with longer text', {
                   position: 'bottom-center',
                   duration: 10000,
-                  description:
-                    'This toast has a description to make it taller',
+                  description: 'This toast has a description to make it taller',
                 });
               }, 500);
               setTimeout(() => {
@@ -464,10 +454,7 @@ const ToastDemo: React.FC = () => {
             onPress={() => {
               toast.promise(
                 new Promise<string>((_, reject) => {
-                  setTimeout(
-                    () => reject(new Error('promise failed')),
-                    2000
-                  );
+                  setTimeout(() => reject(new Error('promise failed')), 2000);
                 }),
                 {
                   loading: 'Loading...',

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/lib/",
-      "<rootDir>/example/"
+      "<rootDir>/example/",
+      "<rootDir>/src/__tests__/test-utils.ts"
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -1,0 +1,45 @@
+import { act } from 'react';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { toastStore } from '../toast-store';
+
+// Single source of truth for resetting ToastStore private state between
+// tests. When a field is added to the store, extend THIS helper — not the
+// individual test files.
+export const resetToastStore = () => {
+  toastStore['state'] = {
+    toasts: [],
+    toastsById: new Map(),
+    toastsCounter: 1,
+    toastRefs: {},
+    shouldShowOverlay: false,
+    toastTimers: {},
+    toastHeights: {},
+    toastHeightsVersion: 0,
+    isExpanded: false,
+  };
+  toastStore['config'] = {};
+  toastStore['subscribers'] = new Set();
+  toastStore['promiseResolvers'] = new Map();
+  toastStore['hideOverlayTimeout'] = null;
+  toastStore['collapseCooldown'] = false;
+  toastStore['collapseCooldownTimeout'] = null;
+};
+
+// afterEach cleanup for tests that mount <Toaster />: dismisses everything and
+// flushes the hide-overlay timer inside act() while the trees are still
+// mounted (so no store notify() fires outside act against a mounted tree),
+// then unmounts every tracked renderer.
+export const cleanupToasterRenderers = (renderers: ReactTestRenderer[]) => {
+  act(() => {
+    toastStore.dismissToast(undefined);
+  });
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  for (const renderer of renderers) {
+    act(() => {
+      renderer.unmount();
+    });
+  }
+  renderers.length = 0;
+};

--- a/src/__tests__/toast-store.test.ts
+++ b/src/__tests__/toast-store.test.ts
@@ -2,6 +2,7 @@ import { ENTERING_ANIMATION_DURATION } from '../animations';
 import { toastStore } from '../toast-store';
 import type { ToastRef } from '../types';
 import type React from 'react';
+import { resetToastStore } from './test-utils';
 
 // Mock React createRef
 jest.mock('react', () => ({
@@ -11,21 +12,7 @@ jest.mock('react', () => ({
 
 describe('ToastStore', () => {
   beforeEach(() => {
-    // Reset the store state before each test
-    toastStore['state'] = {
-      toasts: [],
-      toastsById: new Map(),
-      toastsCounter: 1,
-      toastRefs: {},
-      shouldShowOverlay: false,
-      toastTimers: {},
-      toastHeights: {},
-      toastHeightsVersion: 0,
-      isExpanded: false,
-    };
-    toastStore['config'] = {};
-    toastStore['subscribers'] = new Set();
-    toastStore['promiseResolvers'] = new Map();
+    resetToastStore();
     jest.clearAllTimers();
   });
 
@@ -56,7 +43,11 @@ describe('ToastStore', () => {
     });
 
     it('should add a new toast with custom ID', () => {
-      const toastOptions = { id: 'custom-id', title: 'Custom Toast', variant: 'info' as const };
+      const toastOptions = {
+        id: 'custom-id',
+        title: 'Custom Toast',
+        variant: 'info' as const,
+      };
       const id = toastStore.addToast(toastOptions);
 
       const state = toastStore.getSnapshot();
@@ -68,10 +59,18 @@ describe('ToastStore', () => {
 
     it('should update existing toast when ID matches', () => {
       // Add initial toast
-      toastStore.addToast({ id: 'test-id', title: 'Original Title', variant: 'info' as const });
+      toastStore.addToast({
+        id: 'test-id',
+        title: 'Original Title',
+        variant: 'info' as const,
+      });
 
       // Update the toast
-      toastStore.addToast({ id: 'test-id', title: 'Updated Title', variant: 'info' as const });
+      toastStore.addToast({
+        id: 'test-id',
+        title: 'Updated Title',
+        variant: 'info' as const,
+      });
 
       const state = toastStore.getSnapshot();
       expect(state.toasts).toHaveLength(1);
@@ -160,7 +159,11 @@ describe('ToastStore', () => {
     });
 
     it('should start timer for regular toasts', () => {
-      const id = toastStore.addToast({ title: 'Timed Toast', duration: 2000, variant: 'info' as const });
+      const id = toastStore.addToast({
+        title: 'Timed Toast',
+        duration: 2000,
+        variant: 'info' as const,
+      });
 
       const state = toastStore.getSnapshot();
       expect(state.toastTimers[id]).toBeDefined();
@@ -189,9 +192,21 @@ describe('ToastStore', () => {
   describe('dismissToast', () => {
     beforeEach(() => {
       // Add some toasts for testing
-      toastStore.addToast({ id: 'toast-1', title: 'Toast 1', variant: 'info' as const });
-      toastStore.addToast({ id: 'toast-2', title: 'Toast 2', variant: 'info' as const });
-      toastStore.addToast({ id: 'toast-3', title: 'Toast 3', variant: 'info' as const });
+      toastStore.addToast({
+        id: 'toast-1',
+        title: 'Toast 1',
+        variant: 'info' as const,
+      });
+      toastStore.addToast({
+        id: 'toast-2',
+        title: 'Toast 2',
+        variant: 'info' as const,
+      });
+      toastStore.addToast({
+        id: 'toast-3',
+        title: 'Toast 3',
+        variant: 'info' as const,
+      });
     });
 
     it('should remove single toast by ID', () => {
@@ -257,7 +272,11 @@ describe('ToastStore', () => {
 
   describe('timer management', () => {
     it('should pause timer', () => {
-      const id = toastStore.addToast({ title: 'Test Toast', duration: 2000, variant: 'info' as const });
+      const id = toastStore.addToast({
+        title: 'Test Toast',
+        duration: 2000,
+        variant: 'info' as const,
+      });
 
       toastStore.pauseTimer(id);
 
@@ -266,7 +285,11 @@ describe('ToastStore', () => {
     });
 
     it('should resume timer', () => {
-      const id = toastStore.addToast({ title: 'Test Toast', duration: 2000, variant: 'info' as const });
+      const id = toastStore.addToast({
+        title: 'Test Toast',
+        duration: 2000,
+        variant: 'info' as const,
+      });
 
       toastStore.pauseTimer(id);
       toastStore.resumeTimer(id);
@@ -276,8 +299,16 @@ describe('ToastStore', () => {
     });
 
     it('should pause all timers', () => {
-      const id1 = toastStore.addToast({ title: 'Toast 1', duration: 2000, variant: 'info' as const });
-      const id2 = toastStore.addToast({ title: 'Toast 2', duration: 3000, variant: 'info' as const });
+      const id1 = toastStore.addToast({
+        title: 'Toast 1',
+        duration: 2000,
+        variant: 'info' as const,
+      });
+      const id2 = toastStore.addToast({
+        title: 'Toast 2',
+        duration: 3000,
+        variant: 'info' as const,
+      });
 
       toastStore.pauseAllTimers();
 
@@ -289,8 +320,16 @@ describe('ToastStore', () => {
     it('should resume all timers', () => {
       // This test is difficult with fake timers due to setTimeout mocking
       // Instead, just verify the isPaused flag changes correctly
-      const id1 = toastStore.addToast({ title: 'Toast 1', duration: 2000, variant: 'info' as const });
-      const id2 = toastStore.addToast({ title: 'Toast 2', duration: 3000, variant: 'info' as const });
+      const id1 = toastStore.addToast({
+        title: 'Toast 1',
+        duration: 2000,
+        variant: 'info' as const,
+      });
+      const id2 = toastStore.addToast({
+        title: 'Toast 2',
+        duration: 3000,
+        variant: 'info' as const,
+      });
 
       toastStore.pauseAllTimers();
 
@@ -312,9 +351,19 @@ describe('ToastStore', () => {
     });
 
     it('clears the running timer when a toast is updated to duration: Infinity', () => {
-      const id = toastStore.addToast({ id: 'pin-me', title: 'Uploading', duration: 5000, variant: 'info' as const });
+      const id = toastStore.addToast({
+        id: 'pin-me',
+        title: 'Uploading',
+        duration: 5000,
+        variant: 'info' as const,
+      });
 
-      toastStore.addToast({ id: 'pin-me', title: 'Uploading', duration: Infinity, variant: 'info' as const });
+      toastStore.addToast({
+        id: 'pin-me',
+        title: 'Uploading',
+        duration: Infinity,
+        variant: 'info' as const,
+      });
 
       jest.advanceTimersByTime(60000);
 
@@ -324,9 +373,19 @@ describe('ToastStore', () => {
     });
 
     it('still auto-dismisses when updated from Infinity to a finite duration', () => {
-      const id = toastStore.addToast({ id: 'unpin-me', title: 'Pinned', duration: Infinity, variant: 'info' as const });
+      const id = toastStore.addToast({
+        id: 'unpin-me',
+        title: 'Pinned',
+        duration: Infinity,
+        variant: 'info' as const,
+      });
 
-      toastStore.addToast({ id: 'unpin-me', title: 'Pinned', duration: 2000, variant: 'info' as const });
+      toastStore.addToast({
+        id: 'unpin-me',
+        title: 'Pinned',
+        duration: 2000,
+        variant: 'info' as const,
+      });
 
       jest.advanceTimersByTime(ENTERING_ANIMATION_DURATION + 2000 + 1);
 
@@ -335,7 +394,11 @@ describe('ToastStore', () => {
     });
 
     it('should enforce minimum 1 second when resuming timer', () => {
-      const id = toastStore.addToast({ title: 'Test Toast', duration: 100, variant: 'info' as const }); // Very short duration
+      const id = toastStore.addToast({
+        title: 'Test Toast',
+        duration: 100,
+        variant: 'info' as const,
+      }); // Very short duration
 
       // Pause timer almost immediately
       toastStore.pauseTimer(id);
@@ -370,8 +433,16 @@ describe('ToastStore', () => {
     });
 
     it('should track heights for multiple toasts', () => {
-      toastStore.addToast({ id: 'toast-1', title: 'Toast 1', variant: 'info' as const });
-      toastStore.addToast({ id: 'toast-2', title: 'Toast 2', variant: 'info' as const });
+      toastStore.addToast({
+        id: 'toast-1',
+        title: 'Toast 1',
+        variant: 'info' as const,
+      });
+      toastStore.addToast({
+        id: 'toast-2',
+        title: 'Toast 2',
+        variant: 'info' as const,
+      });
 
       toastStore.setToastHeight('toast-1', 60);
       toastStore.setToastHeight('toast-2', 70);
@@ -385,8 +456,16 @@ describe('ToastStore', () => {
   describe('expand/collapse functionality', () => {
     beforeEach(() => {
       // Add multiple toasts with short durations for faster tests
-      toastStore.addToast({ title: 'Toast 1', duration: 100, variant: 'info' as const });
-      toastStore.addToast({ title: 'Toast 2', duration: 100, variant: 'info' as const });
+      toastStore.addToast({
+        title: 'Toast 1',
+        duration: 100,
+        variant: 'info' as const,
+      });
+      toastStore.addToast({
+        title: 'Toast 2',
+        duration: 100,
+        variant: 'info' as const,
+      });
     });
 
     it('should expand and pause all timers', () => {
@@ -448,9 +527,14 @@ describe('ToastStore', () => {
   describe('wiggle functionality', () => {
     it('should call wiggle on toast ref when available', () => {
       const mockWiggle = jest.fn();
-      const mockRef: React.RefObject<ToastRef | null> = { current: { wiggle: mockWiggle } };
+      const mockRef: React.RefObject<ToastRef | null> = {
+        current: { wiggle: mockWiggle },
+      };
 
-      const id = toastStore.addToast({ title: 'Test Toast', variant: 'info' as const });
+      const id = toastStore.addToast({
+        title: 'Test Toast',
+        variant: 'info' as const,
+      });
 
       // Manually set the ref (normally done by React)
       toastStore['state'].toastRefs[id] = mockRef;
@@ -461,7 +545,10 @@ describe('ToastStore', () => {
     });
 
     it('should not crash when toast ref is not available', () => {
-      const id = toastStore.addToast({ title: 'Test Toast', variant: 'info' as const });
+      const id = toastStore.addToast({
+        title: 'Test Toast',
+        variant: 'info' as const,
+      });
 
       expect(() => {
         toastStore.wiggleToast(id);
@@ -475,7 +562,11 @@ describe('ToastStore', () => {
     });
 
     it('should restart timer on wiggle for finite duration toasts', () => {
-      const id = toastStore.addToast({ title: 'Test Toast', duration: 2000, variant: 'info' as const });
+      const id = toastStore.addToast({
+        title: 'Test Toast',
+        duration: 2000,
+        variant: 'info' as const,
+      });
       const initialTimer = toastStore.getSnapshot().toastTimers[id];
 
       // Wait a bit to change the timer state
@@ -489,7 +580,11 @@ describe('ToastStore', () => {
     });
 
     it('should not restart timer on wiggle for infinite duration toasts', () => {
-      toastStore.addToast({ title: 'Test Toast', duration: Infinity, variant: 'info' as const });
+      toastStore.addToast({
+        title: 'Test Toast',
+        duration: Infinity,
+        variant: 'info' as const,
+      });
 
       toastStore.wiggleToast(1); // Use the generated ID
 
@@ -605,8 +700,16 @@ describe('ToastStore', () => {
     it('overflow trim frees the trimmed toast ref', () => {
       toastStore.setConfig({ visibleToasts: 1 });
 
-      toastStore.addToast({ id: 'first', title: 'first', variant: 'info' as const });
-      toastStore.addToast({ id: 'second', title: 'second', variant: 'info' as const });
+      toastStore.addToast({
+        id: 'first',
+        title: 'first',
+        variant: 'info' as const,
+      });
+      toastStore.addToast({
+        id: 'second',
+        title: 'second',
+        variant: 'info' as const,
+      });
 
       expect(toastStore.getSnapshot().toastRefs['first']).toBeUndefined();
       expect(toastStore.getSnapshot().toastRefs['second']).toBeDefined();

--- a/src/__tests__/toaster-perf.test.tsx
+++ b/src/__tests__/toaster-perf.test.tsx
@@ -74,16 +74,22 @@ describe('Toaster (re-render blast radius)', () => {
     expect(before.length).toBeGreaterThan(0);
     const idsBefore = before[before.length - 1]!.orderedToastIds;
 
+    let idB: string | number = '';
     act(() => {
-      toast('B', { position: 'bottom-center' });
+      idB = toast('B', { position: 'bottom-center' });
+    });
+    // A height write flows through DynamicToastContext and legitimately
+    // re-renders every toast — forcing A to re-render so the identity of
+    // its orderedToastIds prop is verified unconditionally.
+    act(() => {
+      toastStore.setToastHeight(idB, 80);
     });
 
     const after = callsFor(idA);
-    if (after.length > before.length) {
-      // A re-rendered; the array it receives must be the SAME object,
-      // or React.memo can never take effect.
-      expect(after[after.length - 1]!.orderedToastIds).toBe(idsBefore);
-    }
+    expect(after.length).toBeGreaterThan(before.length);
+    // A re-rendered; the array it receives must be the SAME object,
+    // or React.memo can never take effect.
+    expect(after[after.length - 1]!.orderedToastIds).toBe(idsBefore);
   });
 
   it('does not re-render a toast when a toast is added to a different position', () => {

--- a/src/__tests__/toaster-perf.test.tsx
+++ b/src/__tests__/toaster-perf.test.tsx
@@ -3,6 +3,7 @@ import TestRenderer from 'react-test-renderer';
 import { Toaster } from '../toaster';
 import { toast } from '../toast-fns';
 import { toastStore } from '../toast-store';
+import { cleanupToasterRenderers, resetToastStore } from './test-utils';
 
 // Wraps useToastPosition so every Toast render is observable: the hook runs
 // exactly once per Toast body render, and receives the orderedToastIds prop.
@@ -27,45 +28,31 @@ jest.mock('../use-toast-position', () => {
   };
 });
 
-const resetStore = () => {
-  toastStore['state'] = {
-    toasts: [],
-    toastsById: new Map(),
-    toastsCounter: 1,
-    toastRefs: {},
-    shouldShowOverlay: false,
-    toastTimers: {},
-    toastHeights: {},
-    toastHeightsVersion: 0,
-    isExpanded: false,
-  };
-  toastStore['config'] = {};
-  toastStore['subscribers'] = new Set();
-  toastStore['promiseResolvers'] = new Map();
-  toastStore['hideOverlayTimeout'] = null;
-  toastStore['collapseCooldown'] = false;
-  toastStore['collapseCooldownTimeout'] = null;
-};
-
 const callsFor = (id: string | number) =>
   mockPositionCalls.filter((call) => call.id === id);
 
 describe('Toaster (re-render blast radius)', () => {
+  const renderers: TestRenderer.ReactTestRenderer[] = [];
+  const renderToaster = () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(<Toaster />);
+    });
+    renderers.push(renderer);
+    return renderer;
+  };
+
   beforeEach(() => {
-    resetStore();
+    resetToastStore();
     mockPositionCalls.length = 0;
     jest.clearAllTimers();
   });
   afterEach(() => {
-    act(() => {
-      toastStore.dismissToast(undefined);
-    });
+    cleanupToasterRenderers(renderers);
   });
 
   it('keeps orderedToastIds identity stable for a toast when an unrelated position changes', () => {
-    act(() => {
-      TestRenderer.create(<Toaster />);
-    });
+    renderToaster();
     let idA: string | number = '';
     act(() => {
       idA = toast('A');
@@ -93,9 +80,7 @@ describe('Toaster (re-render blast radius)', () => {
   });
 
   it('does not re-render a toast when a toast is added to a different position', () => {
-    act(() => {
-      TestRenderer.create(<Toaster />);
-    });
+    renderToaster();
     let idA: string | number = '';
     act(() => {
       idA = toast('A');
@@ -110,6 +95,44 @@ describe('Toaster (re-render blast radius)', () => {
     const extraRenders = callsFor(idA).length - rendersBefore;
     // A's container (top-center default) is untouched by C; with stable
     // per-position props and React.memo, A must not re-render at all.
+    expect(extraRenders).toBe(0);
+  });
+
+  it('does not re-render a toast when a heightless toast at a different position is dismissed', () => {
+    renderToaster();
+    let idA: string | number = '';
+    let idB: string | number = '';
+    act(() => {
+      idA = toast('A');
+      idB = toast('B', { position: 'bottom-center' });
+    });
+    const rendersBefore = callsFor(idA).length;
+
+    // B never reported a height, so dismissing it must not bump
+    // toastHeightsVersion — and A's position is untouched by the removal.
+    act(() => {
+      toastStore.dismissToast(idB);
+    });
+
+    const extraRenders = callsFor(idA).length - rendersBefore;
+    expect(extraRenders).toBe(0);
+  });
+
+  it('does not re-render toasts when the Toaster host re-renders with unchanged props', () => {
+    const renderer = renderToaster();
+    let idA: string | number = '';
+    act(() => {
+      idA = toast('A');
+    });
+    const rendersBefore = callsFor(idA).length;
+
+    // Only stable props reach Toast (no rest-spread), so a host re-render
+    // with unchanged Toaster props must not defeat React.memo.
+    act(() => {
+      renderer.update(<Toaster />);
+    });
+
+    const extraRenders = callsFor(idA).length - rendersBefore;
     expect(extraRenders).toBe(0);
   });
 });

--- a/src/__tests__/toaster-perf.test.tsx
+++ b/src/__tests__/toaster-perf.test.tsx
@@ -1,0 +1,109 @@
+import { act } from 'react';
+import TestRenderer from 'react-test-renderer';
+import { Toaster } from '../toaster';
+import { toast } from '../toast-fns';
+import { toastStore } from '../toast-store';
+
+// Wraps useToastPosition so every Toast render is observable: the hook runs
+// exactly once per Toast body render, and receives the orderedToastIds prop.
+const mockPositionCalls: Array<{
+  id: string | number;
+  orderedToastIds: Array<string | number>;
+}> = [];
+jest.mock('../use-toast-position', () => {
+  const actual = jest.requireActual('../use-toast-position');
+  return {
+    ...actual,
+    useToastPosition: (args: {
+      id: string | number;
+      orderedToastIds: Array<string | number>;
+    }) => {
+      mockPositionCalls.push({
+        id: args.id,
+        orderedToastIds: args.orderedToastIds,
+      });
+      return actual.useToastPosition(args);
+    },
+  };
+});
+
+const resetStore = () => {
+  toastStore['state'] = {
+    toasts: [],
+    toastsById: new Map(),
+    toastsCounter: 1,
+    toastRefs: {},
+    shouldShowOverlay: false,
+    toastTimers: {},
+    toastHeights: {},
+    toastHeightsVersion: 0,
+    isExpanded: false,
+  };
+  toastStore['config'] = {};
+  toastStore['subscribers'] = new Set();
+  toastStore['promiseResolvers'] = new Map();
+  toastStore['hideOverlayTimeout'] = null;
+  toastStore['collapseCooldown'] = false;
+  toastStore['collapseCooldownTimeout'] = null;
+};
+
+const callsFor = (id: string | number) =>
+  mockPositionCalls.filter((call) => call.id === id);
+
+describe('Toaster (re-render blast radius)', () => {
+  beforeEach(() => {
+    resetStore();
+    mockPositionCalls.length = 0;
+    jest.clearAllTimers();
+  });
+  afterEach(() => {
+    act(() => {
+      toastStore.dismissToast(undefined);
+    });
+  });
+
+  it('keeps orderedToastIds identity stable for a toast when an unrelated position changes', () => {
+    act(() => {
+      TestRenderer.create(<Toaster />);
+    });
+    let idA: string | number = '';
+    act(() => {
+      idA = toast('A');
+    });
+    const before = callsFor(idA);
+    expect(before.length).toBeGreaterThan(0);
+    const idsBefore = before[before.length - 1]!.orderedToastIds;
+
+    act(() => {
+      toast('B', { position: 'bottom-center' });
+    });
+
+    const after = callsFor(idA);
+    if (after.length > before.length) {
+      // A re-rendered; the array it receives must be the SAME object,
+      // or React.memo can never take effect.
+      expect(after[after.length - 1]!.orderedToastIds).toBe(idsBefore);
+    }
+  });
+
+  it('does not re-render a toast when a toast is added to a different position', () => {
+    act(() => {
+      TestRenderer.create(<Toaster />);
+    });
+    let idA: string | number = '';
+    act(() => {
+      idA = toast('A');
+      toast('B', { position: 'bottom-center' });
+    });
+    const rendersBefore = callsFor(idA).length;
+
+    act(() => {
+      toast('C', { position: 'bottom-center' });
+    });
+
+    const extraRenders = callsFor(idA).length - rendersBefore;
+    // A's container (top-center default) is untouched by C; with stable
+    // per-position props and React.memo, A must not re-render at all.
+    expect(extraRenders).toBe(0);
+  });
+});

--- a/src/__tests__/toaster.test.tsx
+++ b/src/__tests__/toaster.test.tsx
@@ -1,59 +1,41 @@
-import { act } from 'react';
+import { act, type ReactElement } from 'react';
 import TestRenderer from 'react-test-renderer';
 import { Positioner } from '../positioner';
 import { Toaster } from '../toaster';
 import { toast } from '../toast-fns';
-import { toastStore } from '../toast-store';
 import type { ToastPosition } from '../types';
-
-const resetStore = () => {
-  toastStore['state'] = {
-    toasts: [],
-    toastsById: new Map(),
-    toastsCounter: 1,
-    toastRefs: {},
-    shouldShowOverlay: false,
-    toastTimers: {},
-    toastHeights: {},
-    toastHeightsVersion: 0,
-    isExpanded: false,
-  };
-  toastStore['config'] = {};
-  toastStore['subscribers'] = new Set();
-  toastStore['promiseResolvers'] = new Map();
-  toastStore['hideOverlayTimeout'] = null;
-  toastStore['collapseCooldown'] = false;
-  toastStore['collapseCooldownTimeout'] = null;
-};
+import { cleanupToasterRenderers, resetToastStore } from './test-utils';
 
 const textOf = (instance: TestRenderer.ReactTestRenderer): string => {
   return JSON.stringify(instance.toJSON());
 };
 
 describe('Toaster (render)', () => {
+  const renderers: TestRenderer.ReactTestRenderer[] = [];
+  const renderToaster = (element: ReactElement) => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(element);
+    });
+    renderers.push(renderer);
+    return renderer;
+  };
+
   beforeEach(() => {
-    resetStore();
+    resetToastStore();
     jest.clearAllTimers();
   });
   afterEach(() => {
-    act(() => {
-      toastStore.dismissToast(undefined);
-    });
+    cleanupToasterRenderers(renderers);
   });
 
   it('renders nothing notable when there are no toasts', () => {
-    let renderer!: TestRenderer.ReactTestRenderer;
-    act(() => {
-      renderer = TestRenderer.create(<Toaster />);
-    });
+    const renderer = renderToaster(<Toaster />);
     expect(textOf(renderer)).not.toContain('Hello world');
   });
 
   it('renders a toast title after toast() is called', () => {
-    let renderer!: TestRenderer.ReactTestRenderer;
-    act(() => {
-      renderer = TestRenderer.create(<Toaster />);
-    });
+    const renderer = renderToaster(<Toaster />);
     act(() => {
       toast('Hello world');
     });
@@ -61,10 +43,7 @@ describe('Toaster (render)', () => {
   });
 
   it('renders the description when provided', () => {
-    let renderer!: TestRenderer.ReactTestRenderer;
-    act(() => {
-      renderer = TestRenderer.create(<Toaster />);
-    });
+    const renderer = renderToaster(<Toaster />);
     act(() => {
       toast('Title here', { description: 'Some description' });
     });
@@ -97,10 +76,7 @@ describe('Toaster (render)', () => {
     };
 
     it('keeps position-less toasts in the Toaster default container when another toast uses an explicit position', () => {
-      let renderer!: TestRenderer.ReactTestRenderer;
-      act(() => {
-        renderer = TestRenderer.create(<Toaster position="bottom-center" />);
-      });
+      const renderer = renderToaster(<Toaster position="bottom-center" />);
       act(() => {
         toast('plain');
         toast('pinned', { position: 'top-center' });
@@ -118,10 +94,7 @@ describe('Toaster (render)', () => {
     });
 
     it('keeps position-less toasts in a center default container alongside an explicit bottom-center toast', () => {
-      let renderer!: TestRenderer.ReactTestRenderer;
-      act(() => {
-        renderer = TestRenderer.create(<Toaster position="center" />);
-      });
+      const renderer = renderToaster(<Toaster position="center" />);
       act(() => {
         toast('floaty');
         toast('grounded', { position: 'bottom-center' });
@@ -142,10 +115,7 @@ describe('Toaster (render)', () => {
     });
 
     it('orders a top-center container newest-first even when the Toaster default is bottom-center', () => {
-      let renderer!: TestRenderer.ReactTestRenderer;
-      act(() => {
-        renderer = TestRenderer.create(<Toaster position="bottom-center" />);
-      });
+      const renderer = renderToaster(<Toaster position="bottom-center" />);
       act(() => {
         toast('a', { position: 'top-center' });
         toast('b', { position: 'top-center' });
@@ -153,7 +123,9 @@ describe('Toaster (render)', () => {
 
       const topPositioner = findPositioner(renderer, 'top-center');
       const titlesInRenderOrder = topPositioner
-        .findAll((node) => node.props?.children === 'a' || node.props?.children === 'b')
+        .findAll(
+          (node) => node.props?.children === 'a' || node.props?.children === 'b'
+        )
         .map((node) => node.props.children);
       // top-center renders newest first (same as a top-center default Toaster)
       expect(titlesInRenderOrder).toEqual(['b', 'a']);
@@ -161,10 +133,7 @@ describe('Toaster (render)', () => {
   });
 
   it('removes the toast after dismiss', () => {
-    let renderer!: TestRenderer.ReactTestRenderer;
-    act(() => {
-      renderer = TestRenderer.create(<Toaster />);
-    });
+    const renderer = renderToaster(<Toaster />);
     let id: string | number = '';
     act(() => {
       id = toast('Dismiss me');

--- a/src/close-button.tsx
+++ b/src/close-button.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Pressable, type ViewProps } from 'react-native';
+import { X } from './icons';
+import type { ToastProps } from './types';
+import type { DefaultStyles } from './use-default-styles';
+
+export const CloseButton: React.FC<{
+  dismissible: ToastProps['dismissible'];
+  close: ToastProps['close'];
+  closeButton: ToastProps['closeButton'];
+  onDismiss: ToastProps['onDismiss'];
+  id: ToastProps['id'];
+  closeButtonStyle?: ViewProps['style'];
+  closeButtonIconStyle?: ViewProps['style'];
+  defaultStyles: DefaultStyles;
+}> = ({
+  dismissible,
+  close,
+  closeButton,
+  onDismiss,
+  id,
+  closeButtonStyle,
+  defaultStyles,
+  closeButtonIconStyle,
+}) => {
+  if (!dismissible) {
+    return null;
+  }
+
+  if (close) {
+    return close;
+  }
+
+  if (closeButton) {
+    return (
+      <Pressable
+        onPress={() => onDismiss?.(id)}
+        hitSlop={10}
+        style={closeButtonStyle}
+      >
+        <X
+          size={20}
+          color={defaultStyles.closeButtonColor}
+          style={closeButtonIconStyle}
+        />
+      </Pressable>
+    );
+  }
+  return null;
+};

--- a/src/close-button.tsx
+++ b/src/close-button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Pressable, type ViewProps } from 'react-native';
+import { Pressable, Text, type ViewProps } from 'react-native';
 import { X } from './icons';
 import type { ToastProps } from './types';
 import type { DefaultStyles } from './use-default-styles';
@@ -28,7 +28,13 @@ export const CloseButton: React.FC<{
   }
 
   if (close) {
-    return close;
+    // `close` typechecks as a bare string/number, which crashes React Native
+    // when rendered directly inside a View.
+    return typeof close === 'string' || typeof close === 'number' ? (
+      <Text>{close}</Text>
+    ) : (
+      close
+    );
   }
 
   if (closeButton) {

--- a/src/positioner.tsx
+++ b/src/positioner.tsx
@@ -52,20 +52,21 @@ export const Positioner: React.FC<
     }
   }, [isExpanded, collapse]);
 
-  const outsidePressableStyle = React.useMemo(
-    () =>
-      calculateOutsidePressableArea({
+  // Don't show expand/collapse for center position
+  const shouldAllowCollapse = resolvedPosition !== 'center' && isExpanded;
+
+  // Only rendered while expanded, so gate (rather than memoize) the
+  // computation: toast height writes in the common collapsed state would
+  // otherwise recompute it on every write for a value never used.
+  const outsidePressableStyle = shouldAllowCollapse
+    ? calculateOutsidePressableArea({
         position: resolvedPosition,
         toastHeights,
         gap,
         visibleToasts: visibleToasts || 3,
         insetValues,
-      }),
-    [resolvedPosition, toastHeights, gap, visibleToasts, insetValues]
-  );
-
-  // Don't show expand/collapse for center position
-  const shouldAllowCollapse = resolvedPosition !== 'center' && isExpanded;
+      })
+    : null;
 
   const hasChildren = React.Children.count(children) > 0;
 

--- a/src/positioner.tsx
+++ b/src/positioner.tsx
@@ -31,13 +31,20 @@ export const Positioner: React.FC<
   const { top, bottom } = useInsets();
 
   const resolvedPosition = position || 'bottom-center';
-  const containerStyle = getContainerStyle(resolvedPosition);
+  const containerStyle = React.useMemo(
+    () => getContainerStyle(resolvedPosition),
+    [resolvedPosition]
+  );
 
-  const insetValues = getInsetValues({
-    position: resolvedPosition,
-    offset,
-    safeAreaInsets: { top, bottom },
-  });
+  const insetValues = React.useMemo(
+    () =>
+      getInsetValues({
+        position: resolvedPosition,
+        offset,
+        safeAreaInsets: { top, bottom },
+      }),
+    [resolvedPosition, offset, top, bottom]
+  );
 
   const handleOutsidePress = React.useCallback(() => {
     if (isExpanded) {
@@ -45,13 +52,17 @@ export const Positioner: React.FC<
     }
   }, [isExpanded, collapse]);
 
-  const outsidePressableStyle = calculateOutsidePressableArea({
-    position: resolvedPosition,
-    toastHeights,
-    gap,
-    visibleToasts: visibleToasts || 3,
-    insetValues,
-  });
+  const outsidePressableStyle = React.useMemo(
+    () =>
+      calculateOutsidePressableArea({
+        position: resolvedPosition,
+        toastHeights,
+        gap,
+        visibleToasts: visibleToasts || 3,
+        insetValues,
+      }),
+    [resolvedPosition, toastHeights, gap, visibleToasts, insetValues]
+  );
 
   // Don't show expand/collapse for center position
   const shouldAllowCollapse = resolvedPosition !== 'center' && isExpanded;

--- a/src/toast-button.tsx
+++ b/src/toast-button.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Pressable, Text } from 'react-native';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+import type { ToastAction } from './types';
+
+// A labeled action/cancel button rendered from a ToastAction.
+export const ToastButton: React.FC<{
+  action: ToastAction;
+  onPress: () => void;
+  allowFontScaling?: boolean;
+  maxFontSizeMultiplier?: number;
+  style: StyleProp<ViewStyle>;
+  textStyle: StyleProp<TextStyle>;
+}> = ({
+  action,
+  onPress,
+  allowFontScaling,
+  maxFontSizeMultiplier,
+  style,
+  textStyle,
+}) => {
+  return (
+    <Pressable onPress={onPress} style={style}>
+      <Text
+        numberOfLines={1}
+        allowFontScaling={allowFontScaling}
+        maxFontSizeMultiplier={maxFontSizeMultiplier}
+        style={textStyle}
+      >
+        {action.label}
+      </Text>
+    </Pressable>
+  );
+};

--- a/src/toast-content.tsx
+++ b/src/toast-content.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import { ActivityIndicator, Text, View } from 'react-native';
+import type { ViewStyle } from 'react-native';
+import { CloseButton } from './close-button';
+import { useToastContext } from './context';
+import { ToastButton } from './toast-button';
+import { ToastIcon } from './toast-icon';
+import { isToastAction, type ToastProps, type ToastStyles } from './types';
+import type { DefaultStyles } from './use-default-styles';
+
+// The visual innards of a standard (non-jsx) toast: icon, title/description,
+// action/cancel buttons, and close button. All `props ?? context` resolution
+// happens in the parent; this component only reads context for Toaster-level
+// toastOptions styles and icon overrides.
+export const ToastContent: React.FC<{
+  id: ToastProps['id'];
+  title: string;
+  description?: string;
+  icon?: React.ReactNode;
+  variant: ToastProps['variant'];
+  action?: ToastProps['action'];
+  cancel?: ToastProps['cancel'];
+  close?: ToastProps['close'];
+  closeButton?: boolean;
+  dismissible: boolean;
+  onDismiss?: ToastProps['onDismiss'];
+  promiseOptions?: ToastProps['promiseOptions'];
+  actionButtonStyle?: ToastProps['actionButtonStyle'];
+  actionButtonTextStyle?: ToastProps['actionButtonTextStyle'];
+  cancelButtonStyle?: ToastProps['cancelButtonStyle'];
+  cancelButtonTextStyle?: ToastProps['cancelButtonTextStyle'];
+  invert: boolean;
+  richColors: boolean;
+  unstyled?: boolean;
+  allowFontScaling?: boolean;
+  maxFontSizeMultiplier?: number;
+  mergedStyles?: ToastStyles;
+  defaultStyles: DefaultStyles;
+  contentContainerStyle?: ViewStyle;
+}> = ({
+  id,
+  title,
+  description,
+  icon,
+  variant,
+  action,
+  cancel,
+  close,
+  closeButton,
+  dismissible,
+  onDismiss,
+  promiseOptions,
+  actionButtonStyle,
+  actionButtonTextStyle,
+  cancelButtonStyle,
+  cancelButtonTextStyle,
+  invert,
+  richColors,
+  unstyled,
+  allowFontScaling,
+  maxFontSizeMultiplier,
+  mergedStyles,
+  defaultStyles,
+  contentContainerStyle,
+}) => {
+  const {
+    icons,
+    toastOptions: {
+      actionButtonStyle: actionButtonStyleCtx,
+      actionButtonTextStyle: actionButtonTextStyleCtx,
+      cancelButtonStyle: cancelButtonStyleCtx,
+      cancelButtonTextStyle: cancelButtonTextStyleCtx,
+      toastContentStyle: toastContentStyleCtx,
+      textContainerStyle: textContainerStyleCtx,
+      titleStyle: titleStyleCtx,
+      descriptionStyle: descriptionStyleCtx,
+      buttonsStyle: buttonsStyleCtx,
+      closeButtonStyle: closeButtonStyleCtx,
+      closeButtonIconStyle: closeButtonIconStyleCtx,
+    },
+  } = useToastContext();
+
+  const onCancelPress = React.useCallback(() => {
+    if (isToastAction(cancel)) {
+      cancel.onClick();
+    }
+    onDismiss?.(id);
+  }, [cancel, onDismiss, id]);
+
+  return (
+    <View
+      style={[
+        defaultStyles.toastContent,
+        toastContentStyleCtx,
+        mergedStyles?.toastContent,
+        contentContainerStyle,
+      ]}
+    >
+      {promiseOptions || variant === 'loading' ? (
+        'loading' in icons ? (
+          icons.loading
+        ) : (
+          <ActivityIndicator />
+        )
+      ) : icon ? (
+        <View>{icon}</View>
+      ) : variant in icons ? (
+        icons[variant]
+      ) : (
+        <ToastIcon variant={variant} invert={invert} richColors={richColors} />
+      )}
+      <View
+        style={[
+          { flex: 1 },
+          textContainerStyleCtx,
+          mergedStyles?.textContainer,
+        ]}
+      >
+        <Text
+          allowFontScaling={allowFontScaling}
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
+          style={[defaultStyles.title, titleStyleCtx, mergedStyles?.title]}
+        >
+          {title}
+        </Text>
+        {description ? (
+          <Text
+            allowFontScaling={allowFontScaling}
+            maxFontSizeMultiplier={maxFontSizeMultiplier}
+            style={[
+              defaultStyles.description,
+              descriptionStyleCtx,
+              mergedStyles?.description,
+            ]}
+          >
+            {description}
+          </Text>
+        ) : null}
+        <View
+          style={[
+            unstyled || (!action && !cancel)
+              ? undefined
+              : defaultStyles.buttons,
+            buttonsStyleCtx,
+            mergedStyles?.buttons,
+          ]}
+        >
+          {isToastAction(action) ? (
+            <ToastButton
+              action={action}
+              onPress={action.onClick}
+              allowFontScaling={allowFontScaling}
+              maxFontSizeMultiplier={maxFontSizeMultiplier}
+              style={[
+                defaultStyles.actionButton,
+                actionButtonStyleCtx,
+                actionButtonStyle,
+              ]}
+              textStyle={[
+                defaultStyles.actionButtonText,
+                actionButtonTextStyleCtx,
+                actionButtonTextStyle,
+              ]}
+            />
+          ) : (
+            action || undefined
+          )}
+          {isToastAction(cancel) ? (
+            <ToastButton
+              action={cancel}
+              onPress={onCancelPress}
+              allowFontScaling={allowFontScaling}
+              maxFontSizeMultiplier={maxFontSizeMultiplier}
+              style={[
+                defaultStyles.cancelButton,
+                cancelButtonStyleCtx,
+                cancelButtonStyle,
+              ]}
+              textStyle={[
+                defaultStyles.cancelButtonText,
+                cancelButtonTextStyleCtx,
+                cancelButtonTextStyle,
+              ]}
+            />
+          ) : (
+            cancel || undefined
+          )}
+        </View>
+      </View>
+      <CloseButton
+        dismissible={dismissible}
+        close={close}
+        closeButton={closeButton}
+        onDismiss={onDismiss}
+        id={id}
+        closeButtonStyle={[closeButtonStyleCtx, mergedStyles?.closeButton]}
+        closeButtonIconStyle={[
+          closeButtonIconStyleCtx,
+          mergedStyles?.closeButtonIcon,
+        ]}
+        defaultStyles={defaultStyles}
+      />
+    </View>
+  );
+};

--- a/src/toast-icon.tsx
+++ b/src/toast-icon.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { CircleCheck, CircleX, Info, TriangleAlert } from './icons';
+import type { ToastProps } from './types';
+import { useIconColor } from './use-default-styles';
+
+export const ToastIcon: React.FC<
+  Pick<ToastProps, 'variant'> & {
+    invert: boolean;
+    richColors: boolean;
+  }
+> = ({ variant, invert, richColors }) => {
+  const color = useIconColor({ variant, invert, richColors });
+
+  switch (variant) {
+    case 'success':
+      return <CircleCheck size={20} color={color} />;
+    case 'error':
+      return <CircleX size={20} color={color} />;
+    case 'warning':
+      return <TriangleAlert size={20} color={color} />;
+    default:
+    case 'info':
+      return <Info size={20} color={color} />;
+  }
+};

--- a/src/toast-store.ts
+++ b/src/toast-store.ts
@@ -383,8 +383,15 @@ class ToastStore {
       (currentToast) => currentToast.id !== id
     );
 
-    const updatedHeights = { ...this.state.toastHeights };
-    delete updatedHeights[id];
+    // Only touch heights (and bump the version) when this toast actually had
+    // a height entry — an unconditional bump would re-render every toast at
+    // every position through DynamicToastContext.
+    const heightsChanged = id in this.state.toastHeights;
+    let updatedHeights = this.state.toastHeights;
+    if (heightsChanged) {
+      updatedHeights = { ...updatedHeights };
+      delete updatedHeights[id];
+    }
 
     const updatedRefs = { ...this.state.toastRefs };
     delete updatedRefs[id];
@@ -401,7 +408,9 @@ class ToastStore {
       toastsById: updatedIndex,
       toastRefs: updatedRefs,
       toastHeights: updatedHeights,
-      toastHeightsVersion: this.state.toastHeightsVersion + 1,
+      toastHeightsVersion: heightsChanged
+        ? this.state.toastHeightsVersion + 1
+        : this.state.toastHeightsVersion,
       isExpanded: shouldAutoCollapse ? false : this.state.isExpanded,
     };
 

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   View,
   useWindowDimensions,
-  type ViewProps,
 } from 'react-native';
 import Animated, {
   useAnimatedStyle,
@@ -18,9 +17,10 @@ import { STACKING_ANIMATION_DURATION, useToastLayoutAnimations } from './animati
 import { toastDefaultValues } from './constants';
 import { useDynamicToastContext, useToastContext } from './context';
 import { easeOutQuartFn } from './easings';
+import { CloseButton } from './close-button';
 import { ToastSwipeHandler } from './gestures';
-import { CircleCheck, CircleX, Info, TriangleAlert, X } from './icons';
 import { isPressNearCloseButton } from './press-utils';
+import { ToastIcon } from './toast-icon';
 import { toastStore } from './toast-store';
 import {
   isToastAction,
@@ -29,11 +29,7 @@ import {
   type ToastStyles,
 } from './types';
 import { useAppStateListener } from './use-app-state';
-import {
-  useDefaultStyles,
-  useIconColor,
-  type DefaultStyles,
-} from './use-default-styles';
+import { useDefaultStyles } from './use-default-styles';
 import { useToastPosition } from './use-toast-position';
 
 type ToastInternalProps = ToastProps & {
@@ -616,27 +612,6 @@ ToastComponent.displayName = 'Toast';
 // stable identities for orderedToastIds/callbacks/toast entries.
 export const Toast = React.memo(ToastComponent);
 
-const ToastIcon: React.FC<
-  Pick<ToastProps, 'variant'> & {
-    invert: boolean;
-    richColors: boolean;
-  }
-> = ({ variant, invert, richColors }) => {
-  const color = useIconColor({ variant, invert, richColors });
-
-  switch (variant) {
-    case 'success':
-      return <CircleCheck size={20} color={color} />;
-    case 'error':
-      return <CircleX size={20} color={color} />;
-    case 'warning':
-      return <TriangleAlert size={20} color={color} />;
-    default:
-    case 'info':
-      return <Info size={20} color={color} />;
-  }
-};
-
 const elevationStyle = {
   shadowOpacity: 0.0015 * 4 + 0.1,
   shadowRadius: 3 * 4,
@@ -647,47 +622,3 @@ const elevationStyle = {
   elevation: 4,
 };
 
-const CloseButton: React.FC<{
-  dismissible: ToastProps['dismissible'];
-  close: ToastProps['close'];
-  closeButton: ToastProps['closeButton'];
-  onDismiss: ToastProps['onDismiss'];
-  id: ToastProps['id'];
-  closeButtonStyle?: ViewProps['style'];
-  closeButtonIconStyle?: ViewProps['style'];
-  defaultStyles: DefaultStyles;
-}> = ({
-  dismissible,
-  close,
-  closeButton,
-  onDismiss,
-  id,
-  closeButtonStyle,
-  defaultStyles,
-  closeButtonIconStyle,
-}) => {
-  if (!dismissible) {
-    return null;
-  }
-
-  if (close) {
-    return close;
-  }
-
-  if (closeButton) {
-    return (
-      <Pressable
-        onPress={() => onDismiss?.(id)}
-        hitSlop={10}
-        style={closeButtonStyle}
-      >
-        <X
-          size={20}
-          color={defaultStyles.closeButtonColor}
-          style={closeButtonIconStyle}
-        />
-      </Pressable>
-    );
-  }
-  return null;
-};

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -13,7 +13,10 @@ import Animated, {
   withRepeat,
   withTiming,
 } from 'react-native-reanimated';
-import { STACKING_ANIMATION_DURATION, useToastLayoutAnimations } from './animations';
+import {
+  STACKING_ANIMATION_DURATION,
+  useToastLayoutAnimations,
+} from './animations';
 import { toastDefaultValues } from './constants';
 import { useDynamicToastContext, useToastContext } from './context';
 import { easeOutQuartFn } from './easings';
@@ -114,12 +117,8 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
         loading: loadingStyleCtx,
       },
     } = useToastContext();
-    const {
-      toastHeights,
-      toastHeightsVersion,
-      isExpanded,
-      toggleExpand,
-    } = useDynamicToastContext();
+    const { toastHeights, toastHeightsVersion, isExpanded, toggleExpand } =
+      useDynamicToastContext();
     const invert = invertProps ?? invertCtx;
     const richColors = richColorsProps ?? richColorsCtx;
     const allowFontScaling = allowFontScalingProps ?? allowFontScalingCtx;
@@ -132,38 +131,42 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
       backgroundComponentProps ?? backgroundComponentCtx;
 
     const mergedStyle = React.useMemo(
-      () =>
-        parentStyle || style
-          ? { ...parentStyle, ...style }
-          : undefined,
+      () => (parentStyle || style ? { ...parentStyle, ...style } : undefined),
       [parentStyle, style]
     );
-    const mergedStyles = React.useMemo(
-      () => {
-        if (!parentStyles && !styles) return undefined;
-        return {
-          toastContainer: { ...parentStyles?.toastContainer, ...styles?.toastContainer },
-          toast: { ...parentStyles?.toast, ...styles?.toast },
-          toastContent: { ...parentStyles?.toastContent, ...styles?.toastContent },
-          textContainer: { ...parentStyles?.textContainer, ...styles?.textContainer },
-          title: { ...parentStyles?.title, ...styles?.title },
-          description: { ...parentStyles?.description, ...styles?.description },
-          buttons: { ...parentStyles?.buttons, ...styles?.buttons },
-          closeButton: { ...parentStyles?.closeButton, ...styles?.closeButton },
-          closeButtonIcon: { ...parentStyles?.closeButtonIcon, ...styles?.closeButtonIcon },
-        };
-      },
-      [parentStyles, styles]
-    );
+    const mergedStyles = React.useMemo(() => {
+      if (!parentStyles && !styles) return undefined;
+      return {
+        toastContainer: {
+          ...parentStyles?.toastContainer,
+          ...styles?.toastContainer,
+        },
+        toast: { ...parentStyles?.toast, ...styles?.toast },
+        toastContent: {
+          ...parentStyles?.toastContent,
+          ...styles?.toastContent,
+        },
+        textContainer: {
+          ...parentStyles?.textContainer,
+          ...styles?.textContainer,
+        },
+        title: { ...parentStyles?.title, ...styles?.title },
+        description: { ...parentStyles?.description, ...styles?.description },
+        buttons: { ...parentStyles?.buttons, ...styles?.buttons },
+        closeButton: { ...parentStyles?.closeButton, ...styles?.closeButton },
+        closeButtonIcon: {
+          ...parentStyles?.closeButtonIcon,
+          ...styles?.closeButtonIcon,
+        },
+      };
+    }, [parentStyles, styles]);
 
     const toastPosition = position ?? positionCtx;
 
     // Determine if this toast should be hidden due to visibility limit
     // For top-center (reversed array), front = index 0; for others, front = highest index
     const distanceFromFront =
-      toastPosition === 'top-center'
-        ? index
-        : numberOfToasts - 1 - index;
+      toastPosition === 'top-center' ? index : numberOfToasts - 1 - index;
     const isHiddenByLimit =
       enableStacking &&
       distanceFromFront >=
@@ -216,9 +219,7 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
       }
 
       const multiplier =
-        toastPosition === 'top-center'
-          ? index
-          : numberOfToasts - index - 1;
+        toastPosition === 'top-center' ? index : numberOfToasts - index - 1;
       const narrowAmount = stackGap * multiplier * 2;
       const scale = Math.max(0.8, 1 - narrowAmount / screenWidth);
       return withTiming(scale, {
@@ -334,11 +335,15 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
     });
 
     const variantStyle =
-      variant === 'success' ? successStyleCtx :
-      variant === 'error' ? errorStyleCtx :
-      variant === 'warning' ? warningStyleCtx :
-      variant === 'info' ? infoStyleCtx :
-      loadingStyleCtx;
+      variant === 'success'
+        ? successStyleCtx
+        : variant === 'error'
+          ? errorStyleCtx
+          : variant === 'warning'
+            ? warningStyleCtx
+            : variant === 'info'
+              ? infoStyleCtx
+              : loadingStyleCtx;
 
     const onRemove = React.useCallback(() => {
       onDismiss?.(id);
@@ -382,7 +387,20 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
         }
         onPress?.();
       },
-      [position, positionCtx, enableStacking, numberOfToasts, toggleExpand, onPress, isExpanded, closeButton, dismissible, onDismiss, id, screenWidth]
+      [
+        position,
+        positionCtx,
+        enableStacking,
+        numberOfToasts,
+        toggleExpand,
+        onPress,
+        isExpanded,
+        closeButton,
+        dismissible,
+        onDismiss,
+        id,
+        screenWidth,
+      ]
     );
 
     const toastSwipeHandlerProps = React.useMemo(
@@ -412,20 +430,14 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
       ]
     );
 
-    const stackZIndex = toastPosition === 'top-center'
-      ? -(index + 1)
-      : -(numberOfToasts - index);
+    const stackZIndex =
+      toastPosition === 'top-center' ? -(index + 1) : -(numberOfToasts - index);
 
     if (jsx) {
       return (
         <Animated.View style={[absolutePositionStyle, { zIndex: stackZIndex }]}>
           <ToastSwipeHandler {...toastSwipeHandlerProps}>
-            <Animated.View
-              ref={toastRef}
-
-              entering={entering}
-              exiting={exiting}
-            >
+            <Animated.View ref={toastRef} entering={entering} exiting={exiting}>
               {jsx}
             </Animated.View>
           </ToastSwipeHandler>
@@ -446,15 +458,10 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
 
     return (
       <Animated.View style={[absolutePositionStyle, { zIndex: stackZIndex }]}>
-        <ToastSwipeHandler
-          {...toastSwipeHandlerProps}
-        >
-          <Animated.View
-            style={wiggleAnimationStyle}
-          >
+        <ToastSwipeHandler {...toastSwipeHandlerProps}>
+          <Animated.View style={wiggleAnimationStyle}>
             <Animated.View
               ref={toastRef}
-
               style={[
                 unstyled ? undefined : elevationStyle,
                 defaultStyles.toast,
@@ -476,112 +483,116 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
                   contentContainerStyle,
                 ]}
               >
-              {promiseOptions || variant === 'loading' ? (
-                'loading' in icons ? (
-                  icons.loading
+                {promiseOptions || variant === 'loading' ? (
+                  'loading' in icons ? (
+                    icons.loading
+                  ) : (
+                    <ActivityIndicator />
+                  )
+                ) : icon ? (
+                  <View>{icon}</View>
+                ) : variant in icons ? (
+                  icons[variant]
                 ) : (
-                  <ActivityIndicator />
-                )
-              ) : icon ? (
-                <View>{icon}</View>
-              ) : variant in icons ? (
-                icons[variant]
-              ) : (
-                <ToastIcon
-                  variant={variant}
-                  invert={invert}
-                  richColors={richColors}
-                />
-              )}
-              <View
-                style={[
-                  { flex: 1 },
-                  textContainerStyleCtx,
-                  mergedStyles?.textContainer,
-                ]}
-              >
-                <Text
-                  allowFontScaling={allowFontScaling}
-                  maxFontSizeMultiplier={maxFontSizeMultiplier}
-                  style={[defaultStyles.title, titleStyleCtx, mergedStyles?.title]}
+                  <ToastIcon
+                    variant={variant}
+                    invert={invert}
+                    richColors={richColors}
+                  />
+                )}
+                <View
+                  style={[
+                    { flex: 1 },
+                    textContainerStyleCtx,
+                    mergedStyles?.textContainer,
+                  ]}
                 >
-                  {title}
-                </Text>
-                {description ? (
                   <Text
                     allowFontScaling={allowFontScaling}
                     maxFontSizeMultiplier={maxFontSizeMultiplier}
                     style={[
-                      defaultStyles.description,
-                      descriptionStyleCtx,
-                      mergedStyles?.description,
+                      defaultStyles.title,
+                      titleStyleCtx,
+                      mergedStyles?.title,
                     ]}
                   >
-                    {description}
+                    {title}
                   </Text>
-                ) : null}
-                <View
-                  style={[
-                    unstyled || (!action && !cancel)
-                      ? undefined
-                      : defaultStyles.buttons,
-                    buttonsStyleCtx,
-                    mergedStyles?.buttons,
-                  ]}
-                >
-                  {isToastAction(action) ? (
-                    <Pressable
-                      onPress={action.onClick}
+                  {description ? (
+                    <Text
+                      allowFontScaling={allowFontScaling}
+                      maxFontSizeMultiplier={maxFontSizeMultiplier}
                       style={[
-                        defaultStyles.actionButton,
-                        actionButtonStyleCtx,
-                        actionButtonStyle,
+                        defaultStyles.description,
+                        descriptionStyleCtx,
+                        mergedStyles?.description,
                       ]}
                     >
-                      <Text
-                        numberOfLines={1}
-                        allowFontScaling={allowFontScaling}
-                        maxFontSizeMultiplier={maxFontSizeMultiplier}
+                      {description}
+                    </Text>
+                  ) : null}
+                  <View
+                    style={[
+                      unstyled || (!action && !cancel)
+                        ? undefined
+                        : defaultStyles.buttons,
+                      buttonsStyleCtx,
+                      mergedStyles?.buttons,
+                    ]}
+                  >
+                    {isToastAction(action) ? (
+                      <Pressable
+                        onPress={action.onClick}
                         style={[
-                          defaultStyles.actionButtonText,
-                          actionButtonTextStyleCtx,
-                          actionButtonTextStyle,
+                          defaultStyles.actionButton,
+                          actionButtonStyleCtx,
+                          actionButtonStyle,
                         ]}
                       >
-                        {action.label}
-                      </Text>
-                    </Pressable>
-                  ) : (
-                    action || undefined
-                  )}
-                  {isToastAction(cancel) ? (
-                    <Pressable
-                      onPress={() => {
-                        cancel.onClick();
-                        onDismiss?.(id);
-                      }}
-                      style={[
-                        defaultStyles.cancelButton,
-                        cancelButtonStyleCtx,
-                        cancelButtonStyle,
-                      ]}
-                    >
-                      <Text
-                        numberOfLines={1}
-                        allowFontScaling={allowFontScaling}
-                        maxFontSizeMultiplier={maxFontSizeMultiplier}
+                        <Text
+                          numberOfLines={1}
+                          allowFontScaling={allowFontScaling}
+                          maxFontSizeMultiplier={maxFontSizeMultiplier}
+                          style={[
+                            defaultStyles.actionButtonText,
+                            actionButtonTextStyleCtx,
+                            actionButtonTextStyle,
+                          ]}
+                        >
+                          {action.label}
+                        </Text>
+                      </Pressable>
+                    ) : (
+                      action || undefined
+                    )}
+                    {isToastAction(cancel) ? (
+                      <Pressable
+                        onPress={() => {
+                          cancel.onClick();
+                          onDismiss?.(id);
+                        }}
                         style={[
-                          defaultStyles.cancelButtonText,
-                          cancelButtonTextStyleCtx,
-                          cancelButtonTextStyle,
+                          defaultStyles.cancelButton,
+                          cancelButtonStyleCtx,
+                          cancelButtonStyle,
                         ]}
                       >
-                        {cancel.label}
-                      </Text>
-                    </Pressable>
-                  ) : (
-                    cancel || undefined
-                  )}
+                        <Text
+                          numberOfLines={1}
+                          allowFontScaling={allowFontScaling}
+                          maxFontSizeMultiplier={maxFontSizeMultiplier}
+                          style={[
+                            defaultStyles.cancelButtonText,
+                            cancelButtonTextStyleCtx,
+                            cancelButtonTextStyle,
+                          ]}
+                        >
+                          {cancel.label}
+                        </Text>
+                      </Pressable>
+                    ) : (
+                      cancel || undefined
+                    )}
                   </View>
                 </View>
                 <CloseButton
@@ -590,7 +601,10 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
                   closeButton={closeButton}
                   onDismiss={onDismiss}
                   id={id}
-                  closeButtonStyle={[closeButtonStyleCtx, mergedStyles?.closeButton]}
+                  closeButtonStyle={[
+                    closeButtonStyleCtx,
+                    mergedStyles?.closeButton,
+                  ]}
                   closeButtonIconStyle={[
                     closeButtonIconStyleCtx,
                     mergedStyles?.closeButtonIcon,
@@ -621,4 +635,3 @@ const elevationStyle = {
   },
   elevation: 4,
 };
-

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -1,39 +1,18 @@
 import * as React from 'react';
-import {
-  ActivityIndicator,
-  Pressable,
-  Text,
-  View,
-  useWindowDimensions,
-} from 'react-native';
-import Animated, {
-  useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  withRepeat,
-  withTiming,
-} from 'react-native-reanimated';
-import {
-  STACKING_ANIMATION_DURATION,
-  useToastLayoutAnimations,
-} from './animations';
+import { View } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { useToastLayoutAnimations } from './animations';
 import { toastDefaultValues } from './constants';
 import { useDynamicToastContext, useToastContext } from './context';
-import { easeOutQuartFn } from './easings';
-import { CloseButton } from './close-button';
 import { ToastSwipeHandler } from './gestures';
-import { isPressNearCloseButton } from './press-utils';
-import { ToastIcon } from './toast-icon';
-import { toastStore } from './toast-store';
-import {
-  isToastAction,
-  type ToastProps,
-  type ToastRef,
-  type ToastStyles,
-} from './types';
-import { useAppStateListener } from './use-app-state';
+import { ToastContent } from './toast-content';
+import { type ToastProps, type ToastRef, type ToastStyles } from './types';
 import { useDefaultStyles } from './use-default-styles';
+import { useMergedStyles } from './use-merged-styles';
+import { useToastAnimations } from './use-toast-animations';
+import { useToastLifecycle } from './use-toast-lifecycle';
 import { useToastPosition } from './use-toast-position';
+import { useToastSwipeProps } from './use-toast-swipe';
 
 type ToastInternalProps = ToastProps & {
   parentStyle?: ToastProps['style'];
@@ -84,8 +63,6 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
     const {
       duration: durationCtx,
       closeButton: closeButtonCtx,
-      icons,
-      pauseWhenPageIsHidden,
       invert: invertCtx,
       richColors: richColorsCtx,
       allowFontScaling: allowFontScalingCtx,
@@ -96,19 +73,7 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
       visibleToasts: visibleToastsCtx,
       toastOptions: {
         unstyled: unstyledCtx,
-        toastContainerStyle: toastContainerStyleCtx,
-        actionButtonStyle: actionButtonStyleCtx,
-        actionButtonTextStyle: actionButtonTextStyleCtx,
-        cancelButtonStyle: cancelButtonStyleCtx,
-        cancelButtonTextStyle: cancelButtonTextStyleCtx,
         style: toastStyleCtx,
-        toastContentStyle: toastContentStyleCtx,
-        textContainerStyle: textContainerStyleCtx,
-        titleStyle: titleStyleCtx,
-        descriptionStyle: descriptionStyleCtx,
-        buttonsStyle: buttonsStyleCtx,
-        closeButtonStyle: closeButtonStyleCtx,
-        closeButtonIconStyle: closeButtonIconStyleCtx,
         backgroundComponent: backgroundComponentCtx,
         success: successStyleCtx,
         error: errorStyleCtx,
@@ -117,7 +82,7 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
         loading: loadingStyleCtx,
       },
     } = useToastContext();
-    const { toastHeights, toastHeightsVersion, isExpanded, toggleExpand } =
+    const { toastHeights, toastHeightsVersion, isExpanded } =
       useDynamicToastContext();
     const invert = invertProps ?? invertCtx;
     const richColors = richColorsProps ?? richColorsCtx;
@@ -130,36 +95,12 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
     const backgroundComponent =
       backgroundComponentProps ?? backgroundComponentCtx;
 
-    const mergedStyle = React.useMemo(
-      () => (parentStyle || style ? { ...parentStyle, ...style } : undefined),
-      [parentStyle, style]
-    );
-    const mergedStyles = React.useMemo(() => {
-      if (!parentStyles && !styles) return undefined;
-      return {
-        toastContainer: {
-          ...parentStyles?.toastContainer,
-          ...styles?.toastContainer,
-        },
-        toast: { ...parentStyles?.toast, ...styles?.toast },
-        toastContent: {
-          ...parentStyles?.toastContent,
-          ...styles?.toastContent,
-        },
-        textContainer: {
-          ...parentStyles?.textContainer,
-          ...styles?.textContainer,
-        },
-        title: { ...parentStyles?.title, ...styles?.title },
-        description: { ...parentStyles?.description, ...styles?.description },
-        buttons: { ...parentStyles?.buttons, ...styles?.buttons },
-        closeButton: { ...parentStyles?.closeButton, ...styles?.closeButton },
-        closeButtonIcon: {
-          ...parentStyles?.closeButtonIcon,
-          ...styles?.closeButtonIcon,
-        },
-      };
-    }, [parentStyles, styles]);
+    const { mergedStyle, mergedStyles } = useMergedStyles({
+      style,
+      styles,
+      parentStyle,
+      parentStyles,
+    });
 
     const toastPosition = position ?? positionCtx;
 
@@ -194,137 +135,38 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
       toastHeightsVersion,
     });
 
-    const isDragging = React.useRef(false);
-    const toastRef = React.useRef<
-      View & { getBoundingClientRect?: () => DOMRect }
-    >(null);
-
-    const wiggleSharedValue = useSharedValue(1);
-
-    const wiggleAnimationStyle = useAnimatedStyle(() => {
-      return {
-        transform: [{ scale: wiggleSharedValue.value }],
-      };
-    }, [wiggleSharedValue]);
-
-    // ScaleX: visual narrowing avoids layout-width changes that cause text rewrap
-    const { width: screenWidth } = useWindowDimensions();
-    const stackScaleX = useDerivedValue(() => {
-      'worklet';
-      if (!enableStacking || numberOfToasts <= 1 || isExpanded) {
-        return withTiming(1, {
-          duration: STACKING_ANIMATION_DURATION,
-          easing: easeOutQuartFn,
-        });
-      }
-
-      const multiplier =
-        toastPosition === 'top-center' ? index : numberOfToasts - index - 1;
-      const narrowAmount = stackGap * multiplier * 2;
-      const scale = Math.max(0.8, 1 - narrowAmount / screenWidth);
-      return withTiming(scale, {
-        duration: STACKING_ANIMATION_DURATION,
-        easing: easeOutQuartFn,
-      });
-    }, [
-      enableStacking,
-      numberOfToasts,
-      index,
+    const {
+      absolutePositionStyle,
+      stackZIndex,
+      wiggleAnimationStyle,
+      wiggleHandler,
+    } = useToastAnimations({
       toastPosition,
+      index,
+      numberOfToasts,
+      enableStacking,
       isExpanded,
       stackGap,
-      screenWidth,
-    ]);
-
-    const absolutePositionStyle = useAnimatedStyle(() => {
-      const base: Record<string, unknown> = {
-        position: 'absolute',
-        width: '100%',
-        transform: [
-          { translateY: yPosition.value },
-          { scaleX: stackScaleX.value },
-        ],
-      };
-      if (toastPosition === 'bottom-center') {
-        base.bottom = 0;
-      } else {
-        base.top = 0;
-      }
-      return base;
-    }, [yPosition, toastPosition, stackScaleX]);
-
-    const wiggle = React.useCallback(() => {
-      'worklet';
-
-      wiggleSharedValue.value = withRepeat(
-        withTiming(Math.min(wiggleSharedValue.value * 1.035, 1.035), {
-          duration: 150,
-        }),
-        4,
-        true
-      );
-    }, [wiggleSharedValue]);
-
-    const wiggleHandler = React.useCallback(() => {
-      // we can't send Infinity over to the native layer.
-      if (duration === Infinity) {
-        return;
-      }
-
-      if (wiggleSharedValue.value !== 1) {
-        // we should animate back to 1 and then wiggle
-        wiggleSharedValue.value = withTiming(1, { duration: 150 }, wiggle);
-      } else {
-        wiggle();
-      }
-    }, [wiggle, wiggleSharedValue, duration]);
+      duration,
+      yPosition,
+    });
 
     React.useImperativeHandle(ref, () => ({
       wiggle: wiggleHandler,
     }));
 
-    const onBackground = React.useCallback(() => {
-      if (!pauseWhenPageIsHidden) {
-        return;
-      }
-      toastStore.pauseTimer(id);
-    }, [pauseWhenPageIsHidden, id]);
+    const toastRef = React.useRef<
+      View & { getBoundingClientRect?: () => DOMRect }
+    >(null);
 
-    const onForeground = React.useCallback(() => {
-      if (!pauseWhenPageIsHidden) {
-        return;
-      }
-      toastStore.resumeTimer(id);
-    }, [pauseWhenPageIsHidden, id]);
-
-    useAppStateListener({
-      onBackground,
-      onForeground,
+    useToastLifecycle({
+      id,
+      toastRef,
+      variant,
+      title,
+      description,
+      jsx,
     });
-
-    // Synchronous layout read via getBoundingClientRect when available
-    // (refs are ReactNativeElement by default from RN 0.83). Older New Arch
-    // versions (e.g. RN 0.81/Expo SDK 54) don't expose it on refs, so fall
-    // back to async measureInWindow.
-    React.useLayoutEffect(() => {
-      if (!toastRef.current) {
-        return;
-      }
-      if (typeof toastRef.current.getBoundingClientRect === 'function') {
-        const { height } = toastRef.current.getBoundingClientRect();
-        toastStore.setToastHeight(id, height);
-        return;
-      }
-      let stale = false;
-      toastRef.current.measureInWindow((_x, _y, _w, height) => {
-        if (!stale) {
-          toastStore.setToastHeight(id, height);
-        }
-      });
-      return () => {
-        stale = true;
-      };
-    }, [id, variant, title, description, jsx]);
 
     const defaultStyles = useDefaultStyles({
       invert,
@@ -345,93 +187,19 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
               ? infoStyleCtx
               : loadingStyleCtx;
 
-    const onRemove = React.useCallback(() => {
-      onDismiss?.(id);
-    }, [onDismiss, id]);
-
-    const onSwipeBegin = React.useCallback(() => {
-      isDragging.current = true;
-      toastStore.pauseTimer(id);
-    }, [id]);
-
-    const onSwipeFinalize = React.useCallback(() => {
-      isDragging.current = false;
-      if (!isExpanded) {
-        toastStore.resumeTimer(id);
-      }
-    }, [id, isExpanded]);
-
-    const onSwipePress = React.useCallback(
-      ({ x }: { x: number; y: number }) => {
-        const pressToastPosition = position || positionCtx;
-        if (
-          enableStacking &&
-          numberOfToasts > 1 &&
-          pressToastPosition !== 'center'
-        ) {
-          if (
-            isPressNearCloseButton({
-              x,
-              viewWidth: screenWidth,
-            })
-          ) {
-            // On Android, the RNGH Tap gesture intercepts the touch before
-            // it reaches the native Pressable (close button). Dismiss
-            // explicitly when tapping the close button area while expanded.
-            if (isExpanded && closeButton && dismissible) {
-              onDismiss?.(id);
-            }
-          } else {
-            toggleExpand();
-          }
-        }
-        onPress?.();
-      },
-      [
-        position,
-        positionCtx,
-        enableStacking,
-        numberOfToasts,
-        toggleExpand,
-        onPress,
-        isExpanded,
-        closeButton,
-        dismissible,
-        onDismiss,
-        id,
-        screenWidth,
-      ]
-    );
-
-    const toastSwipeHandlerProps = React.useMemo(
-      () => ({
-        onRemove,
-        onBegin: onSwipeBegin,
-        onFinalize: onSwipeFinalize,
-        onPress: onSwipePress,
-        enabled: !promiseOptions && dismissible,
-        style: [toastContainerStyleCtx, mergedStyles?.toastContainer],
-        unstyled,
-        important,
-        position,
-      }),
-      [
-        onRemove,
-        onSwipeBegin,
-        onSwipeFinalize,
-        onSwipePress,
-        promiseOptions,
-        dismissible,
-        toastContainerStyleCtx,
-        mergedStyles?.toastContainer,
-        unstyled,
-        important,
-        position,
-      ]
-    );
-
-    const stackZIndex =
-      toastPosition === 'top-center' ? -(index + 1) : -(numberOfToasts - index);
+    const toastSwipeHandlerProps = useToastSwipeProps({
+      id,
+      position,
+      numberOfToasts,
+      dismissible,
+      closeButton,
+      promiseOptions,
+      important,
+      unstyled,
+      mergedContainerStyle: mergedStyles?.toastContainer,
+      onDismiss,
+      onPress,
+    });
 
     if (jsx) {
       return (
@@ -475,143 +243,32 @@ const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
               exiting={exiting}
             >
               {backgroundComponent}
-              <View
-                style={[
-                  defaultStyles.toastContent,
-                  toastContentStyleCtx,
-                  mergedStyles?.toastContent,
-                  contentContainerStyle,
-                ]}
-              >
-                {promiseOptions || variant === 'loading' ? (
-                  'loading' in icons ? (
-                    icons.loading
-                  ) : (
-                    <ActivityIndicator />
-                  )
-                ) : icon ? (
-                  <View>{icon}</View>
-                ) : variant in icons ? (
-                  icons[variant]
-                ) : (
-                  <ToastIcon
-                    variant={variant}
-                    invert={invert}
-                    richColors={richColors}
-                  />
-                )}
-                <View
-                  style={[
-                    { flex: 1 },
-                    textContainerStyleCtx,
-                    mergedStyles?.textContainer,
-                  ]}
-                >
-                  <Text
-                    allowFontScaling={allowFontScaling}
-                    maxFontSizeMultiplier={maxFontSizeMultiplier}
-                    style={[
-                      defaultStyles.title,
-                      titleStyleCtx,
-                      mergedStyles?.title,
-                    ]}
-                  >
-                    {title}
-                  </Text>
-                  {description ? (
-                    <Text
-                      allowFontScaling={allowFontScaling}
-                      maxFontSizeMultiplier={maxFontSizeMultiplier}
-                      style={[
-                        defaultStyles.description,
-                        descriptionStyleCtx,
-                        mergedStyles?.description,
-                      ]}
-                    >
-                      {description}
-                    </Text>
-                  ) : null}
-                  <View
-                    style={[
-                      unstyled || (!action && !cancel)
-                        ? undefined
-                        : defaultStyles.buttons,
-                      buttonsStyleCtx,
-                      mergedStyles?.buttons,
-                    ]}
-                  >
-                    {isToastAction(action) ? (
-                      <Pressable
-                        onPress={action.onClick}
-                        style={[
-                          defaultStyles.actionButton,
-                          actionButtonStyleCtx,
-                          actionButtonStyle,
-                        ]}
-                      >
-                        <Text
-                          numberOfLines={1}
-                          allowFontScaling={allowFontScaling}
-                          maxFontSizeMultiplier={maxFontSizeMultiplier}
-                          style={[
-                            defaultStyles.actionButtonText,
-                            actionButtonTextStyleCtx,
-                            actionButtonTextStyle,
-                          ]}
-                        >
-                          {action.label}
-                        </Text>
-                      </Pressable>
-                    ) : (
-                      action || undefined
-                    )}
-                    {isToastAction(cancel) ? (
-                      <Pressable
-                        onPress={() => {
-                          cancel.onClick();
-                          onDismiss?.(id);
-                        }}
-                        style={[
-                          defaultStyles.cancelButton,
-                          cancelButtonStyleCtx,
-                          cancelButtonStyle,
-                        ]}
-                      >
-                        <Text
-                          numberOfLines={1}
-                          allowFontScaling={allowFontScaling}
-                          maxFontSizeMultiplier={maxFontSizeMultiplier}
-                          style={[
-                            defaultStyles.cancelButtonText,
-                            cancelButtonTextStyleCtx,
-                            cancelButtonTextStyle,
-                          ]}
-                        >
-                          {cancel.label}
-                        </Text>
-                      </Pressable>
-                    ) : (
-                      cancel || undefined
-                    )}
-                  </View>
-                </View>
-                <CloseButton
-                  dismissible={dismissible}
-                  close={close}
-                  closeButton={closeButton}
-                  onDismiss={onDismiss}
-                  id={id}
-                  closeButtonStyle={[
-                    closeButtonStyleCtx,
-                    mergedStyles?.closeButton,
-                  ]}
-                  closeButtonIconStyle={[
-                    closeButtonIconStyleCtx,
-                    mergedStyles?.closeButtonIcon,
-                  ]}
-                  defaultStyles={defaultStyles}
-                />
-              </View>
+              <ToastContent
+                id={id}
+                title={title}
+                description={description}
+                icon={icon}
+                variant={variant}
+                action={action}
+                cancel={cancel}
+                close={close}
+                closeButton={closeButton}
+                dismissible={dismissible}
+                onDismiss={onDismiss}
+                promiseOptions={promiseOptions}
+                actionButtonStyle={actionButtonStyle}
+                actionButtonTextStyle={actionButtonTextStyle}
+                cancelButtonStyle={cancelButtonStyle}
+                cancelButtonTextStyle={cancelButtonTextStyle}
+                invert={invert}
+                richColors={richColors}
+                unstyled={unstyled}
+                allowFontScaling={allowFontScaling}
+                maxFontSizeMultiplier={maxFontSizeMultiplier}
+                mergedStyles={mergedStyles}
+                defaultStyles={defaultStyles}
+                contentContainerStyle={contentContainerStyle}
+              />
             </Animated.View>
           </Animated.View>
         </ToastSwipeHandler>

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -41,7 +41,7 @@ type ToastInternalProps = ToastProps & {
   parentStyles?: ToastStyles;
 };
 
-export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
+const ToastComponent = React.forwardRef<ToastRef, ToastInternalProps>(
   (
     {
       id,
@@ -610,7 +610,11 @@ export const Toast = React.forwardRef<ToastRef, ToastInternalProps>(
   }
 );
 
-Toast.displayName = 'Toast';
+ToastComponent.displayName = 'Toast';
+
+// Default shallow comparison — effective because ToasterUI hands out
+// stable identities for orderedToastIds/callbacks/toast entries.
+export const Toast = React.memo(ToastComponent);
 
 const ToastIcon: React.FC<
   Pick<ToastProps, 'variant'> & {

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -30,6 +30,31 @@ function areArrayItemsIdentical<T>(a: readonly T[], b: readonly T[]): boolean {
   return a.length === b.length && a.every((item, i) => item === b[i]);
 }
 
+// Every PositionData field needs a comparator here: adding a field without
+// deciding how it participates in cache-entry reuse is a type error, so a new
+// field can never be silently served stale from positionsCache.
+const positionDataComparators: {
+  [K in keyof PositionData]: (
+    a: PositionData[K],
+    b: PositionData[K]
+  ) => boolean;
+} = {
+  position: (a, b) => a === b,
+  toasts: areArrayItemsIdentical,
+  orderedToastIds: areArrayItemsIdentical,
+};
+
+function arePositionEntriesEqual(a: PositionData, b: PositionData): boolean {
+  return (
+    Object.keys(positionDataComparators) as Array<keyof PositionData>
+  ).every((key) =>
+    (positionDataComparators[key] as (x: unknown, y: unknown) => boolean)(
+      a[key],
+      b[key]
+    )
+  );
+}
+
 function orderToastsFromPosition(
   currentToasts: ToastProps[],
   position: ToastPosition
@@ -49,9 +74,21 @@ export const Toaster: React.FC<ToasterProps> = ({
     toastStore.getSnapshot
   );
 
-  const { toasts, shouldShowOverlay, toastHeights, isExpanded, toastHeightsVersion } = storeState;
+  const {
+    toasts,
+    shouldShowOverlay,
+    toastHeights,
+    isExpanded,
+    toastHeightsVersion,
+  } = storeState;
 
-  const uiProps = { ...toasterProps, toasts, toastHeights, isExpanded, toastHeightsVersion };
+  const uiProps = {
+    ...toasterProps,
+    toasts,
+    toastHeights,
+    isExpanded,
+    toastHeightsVersion,
+  };
 
   if (!shouldShowOverlay) {
     return <ToasterUI {...uiProps} />;
@@ -108,7 +145,10 @@ const ToasterUI: React.FC<
   animation,
   ToastWrapper,
   positionerStyle,
-  ...props
+  unstyled,
+  style,
+  styles,
+  backgroundComponent,
 }) => {
   React.useEffect(() => {
     toastStore.setConfig({
@@ -210,6 +250,9 @@ const ToasterUI: React.FC<
         currentPosition
       );
       if (toastsForPosition.length === 0 && position !== currentPosition) {
+        // Drop the cached entry so its ToastProps (jsx, closures) don't
+        // outlive the dismissed toasts.
+        positionsCache.delete(currentPosition);
         continue;
       }
       const orderedToastIds = getOrderedToastIds(
@@ -217,17 +260,20 @@ const ToasterUI: React.FC<
         currentPosition,
         enableStacking
       );
-      // Read-then-overwrite per key, never clear: an interrupted render
-      // leaves every entry either previous or freshly computed — both
-      // valid baselines for the next render's identity comparison. The
-      // map is bounded by allPositions (3 entries).
+      // Read-then-overwrite per key: an interrupted render leaves every
+      // entry either previous or freshly computed — both valid baselines
+      // for the next render's identity comparison. The map is bounded by
+      // allPositions (3 entries) and pruned when a position empties.
       const previousEntry = positionsCache.get(currentPosition);
+      const nextEntry: PositionData = {
+        position: currentPosition,
+        toasts: toastsForPosition,
+        orderedToastIds,
+      };
       const entry =
-        previousEntry &&
-        areArrayItemsIdentical(previousEntry.toasts, toastsForPosition) &&
-        areArrayItemsIdentical(previousEntry.orderedToastIds, orderedToastIds)
+        previousEntry && arePositionEntriesEqual(previousEntry, nextEntry)
           ? previousEntry
-          : { position: currentPosition, toasts: toastsForPosition, orderedToastIds };
+          : nextEntry;
       positionsCache.set(currentPosition, entry);
       data.push(entry);
     }
@@ -237,47 +283,56 @@ const ToasterUI: React.FC<
   return (
     <ToastContext.Provider value={value}>
       <DynamicToastContext.Provider value={dynamicValue}>
-      {positionsData.map(({ position: currentPosition, toasts: toastsForPosition, orderedToastIds }) => {
-        return (
-        <Positioner
-          key={currentPosition}
-          style={positionerStyle}
-          position={currentPosition}
-        >
-          {toastsForPosition
-            .map((toastToRender, index) => {
-              const ToastToRender = (
-                <Toast
-                  key={toastToRender.id}
-                  {...props}
-                  {...toastToRender}
-                  parentStyle={props.style}
-                  parentStyles={props.styles}
-                  onDismiss={onDismiss}
-                  onAutoClose={onAutoClose}
-                  index={index}
-                  ref={toastStore.getToastRef(toastToRender.id)}
-                  numberOfToasts={toastsForPosition.length}
-                  orderedToastIds={orderedToastIds}
-                />
-              );
+        {positionsData.map(
+          ({
+            position: currentPosition,
+            toasts: toastsForPosition,
+            orderedToastIds,
+          }) => {
+            return (
+              <Positioner
+                key={currentPosition}
+                style={positionerStyle}
+                position={currentPosition}
+              >
+                {toastsForPosition.map((toastToRender, index) => {
+                  // Toast is React.memo'd on shallow prop identity — pass only
+                  // the props it consumes, explicitly, so nothing object-valued
+                  // slips in through a rest-spread and silently defeats memo.
+                  const ToastToRender = (
+                    <Toast
+                      key={toastToRender.id}
+                      unstyled={unstyled}
+                      backgroundComponent={backgroundComponent}
+                      {...toastToRender}
+                      parentStyle={style}
+                      parentStyles={styles}
+                      onDismiss={onDismiss}
+                      onAutoClose={onAutoClose}
+                      index={index}
+                      ref={toastStore.getToastRef(toastToRender.id)}
+                      numberOfToasts={toastsForPosition.length}
+                      orderedToastIds={orderedToastIds}
+                    />
+                  );
 
-              if (ToastWrapper) {
-                return (
-                  <ToastWrapper
-                    key={toastToRender.id}
-                    toastId={toastToRender.id}
-                  >
-                    {ToastToRender}
-                  </ToastWrapper>
-                );
-              }
-              return ToastToRender;
-            })}
-        </Positioner>
-        );
-      })}
-    </DynamicToastContext.Provider>
+                  if (ToastWrapper) {
+                    return (
+                      <ToastWrapper
+                        key={toastToRender.id}
+                        toastId={toastToRender.id}
+                      >
+                        {ToastToRender}
+                      </ToastWrapper>
+                    );
+                  }
+                  return ToastToRender;
+                })}
+              </Positioner>
+            );
+          }
+        )}
+      </DynamicToastContext.Provider>
     </ToastContext.Provider>
   );
 };

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -20,6 +20,16 @@ const EMPTY_TOAST_OPTIONS: NonNullable<ToasterProps['toastOptions']> = {};
 const EMPTY_ICONS: NonNullable<ToasterProps['icons']> = {};
 const EMPTY_ANIMATION: NonNullable<ToasterProps['animation']> = {};
 
+type PositionData = {
+  position: ToastPosition;
+  toasts: ToastProps[];
+  orderedToastIds: Array<string | number>;
+};
+
+function areArrayItemsIdentical<T>(a: readonly T[], b: readonly T[]): boolean {
+  return a.length === b.length && a.every((item, i) => item === b[i]);
+}
+
 function orderToastsFromPosition(
   currentToasts: ToastProps[],
   position: ToastPosition
@@ -180,22 +190,27 @@ const ToasterUI: React.FC<
     toastStore.dismissToast(id, 'onAutoClose');
   }, []);
 
-  const possiblePositions = React.useMemo(
-    () =>
-      allPositions.filter(
+  // Per-position render data with stable identities: entries (and their
+  // toasts/orderedToastIds arrays) are reused from the previous render when
+  // their contents are unchanged, so React.memo on Toast can bail out for
+  // positions untouched by a store change.
+  // useState (not useRef): the react-hooks/refs rule forbids ref reads in
+  // render; this Map is a memo table whose writes are render-idempotent.
+  const [positionsCache] = React.useState(
+    () => new Map<string, PositionData>()
+  );
+  const positionsData = React.useMemo(() => {
+    const previous = new Map(positionsCache);
+    positionsCache.clear();
+    const data = allPositions
+      .filter(
         (possiblePosition) =>
           toasts.find(
             (positionedToast) =>
               positionedToast.position === possiblePosition
           ) || position === possiblePosition
-      ),
-    [toasts, position]
-  );
-
-  return (
-    <ToastContext.Provider value={value}>
-      <DynamicToastContext.Provider value={dynamicValue}>
-      {possiblePositions.map((currentPosition) => {
+      )
+      .map((currentPosition) => {
         const toastsForPosition = orderToastsFromPosition(
           toasts.filter(
             (possibleToast) =>
@@ -208,6 +223,26 @@ const ToasterUI: React.FC<
           currentPosition,
           enableStacking
         );
+        const previousEntry = previous.get(currentPosition);
+        const entry =
+          previousEntry &&
+          areArrayItemsIdentical(previousEntry.toasts, toastsForPosition) &&
+          areArrayItemsIdentical(
+            previousEntry.orderedToastIds,
+            orderedToastIds
+          )
+            ? previousEntry
+            : { position: currentPosition, toasts: toastsForPosition, orderedToastIds };
+        positionsCache.set(currentPosition, entry);
+        return entry;
+      });
+    return data;
+  }, [positionsCache, toasts, position, enableStacking]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      <DynamicToastContext.Provider value={dynamicValue}>
+      {positionsData.map(({ position: currentPosition, toasts: toastsForPosition, orderedToastIds }) => {
         return (
         <Positioner
           key={currentPosition}

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -200,8 +200,6 @@ const ToasterUI: React.FC<
     () => new Map<string, PositionData>()
   );
   const positionsData = React.useMemo(() => {
-    const previous = new Map(positionsCache);
-    positionsCache.clear();
     const data = allPositions
       .filter(
         (possiblePosition) =>
@@ -223,7 +221,11 @@ const ToasterUI: React.FC<
           currentPosition,
           enableStacking
         );
-        const previousEntry = previous.get(currentPosition);
+        // Read-then-overwrite per key, never clear: an interrupted render
+        // leaves every entry either previous or freshly computed — both
+        // valid baselines for the next render's identity comparison. The
+        // map is bounded by allPositions (3 entries).
+        const previousEntry = positionsCache.get(currentPosition);
         const entry =
           previousEntry &&
           areArrayItemsIdentical(previousEntry.toasts, toastsForPosition) &&

--- a/src/toaster.tsx
+++ b/src/toaster.tsx
@@ -200,44 +200,37 @@ const ToasterUI: React.FC<
     () => new Map<string, PositionData>()
   );
   const positionsData = React.useMemo(() => {
-    const data = allPositions
-      .filter(
-        (possiblePosition) =>
-          toasts.find(
-            (positionedToast) =>
-              positionedToast.position === possiblePosition
-          ) || position === possiblePosition
-      )
-      .map((currentPosition) => {
-        const toastsForPosition = orderToastsFromPosition(
-          toasts.filter(
-            (possibleToast) =>
-              (possibleToast.position ?? position) === currentPosition
-          ),
-          currentPosition
-        );
-        const orderedToastIds = getOrderedToastIds(
-          toastsForPosition,
-          currentPosition,
-          enableStacking
-        );
-        // Read-then-overwrite per key, never clear: an interrupted render
-        // leaves every entry either previous or freshly computed — both
-        // valid baselines for the next render's identity comparison. The
-        // map is bounded by allPositions (3 entries).
-        const previousEntry = positionsCache.get(currentPosition);
-        const entry =
-          previousEntry &&
-          areArrayItemsIdentical(previousEntry.toasts, toastsForPosition) &&
-          areArrayItemsIdentical(
-            previousEntry.orderedToastIds,
-            orderedToastIds
-          )
-            ? previousEntry
-            : { position: currentPosition, toasts: toastsForPosition, orderedToastIds };
-        positionsCache.set(currentPosition, entry);
-        return entry;
-      });
+    const data: PositionData[] = [];
+    for (const currentPosition of allPositions) {
+      const toastsForPosition = orderToastsFromPosition(
+        toasts.filter(
+          (possibleToast) =>
+            (possibleToast.position ?? position) === currentPosition
+        ),
+        currentPosition
+      );
+      if (toastsForPosition.length === 0 && position !== currentPosition) {
+        continue;
+      }
+      const orderedToastIds = getOrderedToastIds(
+        toastsForPosition,
+        currentPosition,
+        enableStacking
+      );
+      // Read-then-overwrite per key, never clear: an interrupted render
+      // leaves every entry either previous or freshly computed — both
+      // valid baselines for the next render's identity comparison. The
+      // map is bounded by allPositions (3 entries).
+      const previousEntry = positionsCache.get(currentPosition);
+      const entry =
+        previousEntry &&
+        areArrayItemsIdentical(previousEntry.toasts, toastsForPosition) &&
+        areArrayItemsIdentical(previousEntry.orderedToastIds, orderedToastIds)
+          ? previousEntry
+          : { position: currentPosition, toasts: toastsForPosition, orderedToastIds };
+      positionsCache.set(currentPosition, entry);
+      data.push(entry);
+    }
     return data;
   }, [positionsCache, toasts, position, enableStacking]);
 

--- a/src/use-merged-styles.ts
+++ b/src/use-merged-styles.ts
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import type { ToastProps, ToastStyles } from './types';
+
+// Merges Toaster-level (parent) and toast-level style props with stable
+// identities so downstream memo/dep comparisons hold.
+export const useMergedStyles = ({
+  style,
+  styles,
+  parentStyle,
+  parentStyles,
+}: {
+  style?: ToastProps['style'];
+  styles?: ToastStyles;
+  parentStyle?: ToastProps['style'];
+  parentStyles?: ToastStyles;
+}) => {
+  const mergedStyle = React.useMemo(
+    () => (parentStyle || style ? { ...parentStyle, ...style } : undefined),
+    [parentStyle, style]
+  );
+  const mergedStyles = React.useMemo(() => {
+    if (!parentStyles && !styles) return undefined;
+    return {
+      toastContainer: {
+        ...parentStyles?.toastContainer,
+        ...styles?.toastContainer,
+      },
+      toast: { ...parentStyles?.toast, ...styles?.toast },
+      toastContent: {
+        ...parentStyles?.toastContent,
+        ...styles?.toastContent,
+      },
+      textContainer: {
+        ...parentStyles?.textContainer,
+        ...styles?.textContainer,
+      },
+      title: { ...parentStyles?.title, ...styles?.title },
+      description: { ...parentStyles?.description, ...styles?.description },
+      buttons: { ...parentStyles?.buttons, ...styles?.buttons },
+      closeButton: { ...parentStyles?.closeButton, ...styles?.closeButton },
+      closeButtonIcon: {
+        ...parentStyles?.closeButtonIcon,
+        ...styles?.closeButtonIcon,
+      },
+    };
+  }, [parentStyles, styles]);
+
+  return { mergedStyle, mergedStyles };
+};

--- a/src/use-toast-animations.ts
+++ b/src/use-toast-animations.ts
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { useWindowDimensions } from 'react-native';
+import {
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
+import { STACKING_ANIMATION_DURATION } from './animations';
+import { easeOutQuartFn } from './easings';
+import type { ToastPosition } from './types';
+
+// Wiggle, stacking scaleX narrowing, and the absolute stack-position style
+// for a single toast.
+export const useToastAnimations = ({
+  toastPosition,
+  index,
+  numberOfToasts,
+  enableStacking,
+  isExpanded,
+  stackGap,
+  duration,
+  yPosition,
+}: {
+  toastPosition: ToastPosition;
+  index: number;
+  numberOfToasts: number;
+  enableStacking: boolean;
+  isExpanded: boolean;
+  stackGap: number;
+  duration: number;
+  yPosition: SharedValue<number>;
+}) => {
+  const wiggleSharedValue = useSharedValue(1);
+
+  const wiggleAnimationStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{ scale: wiggleSharedValue.value }],
+    };
+  }, [wiggleSharedValue]);
+
+  // ScaleX: visual narrowing avoids layout-width changes that cause text rewrap
+  const { width: screenWidth } = useWindowDimensions();
+  const stackScaleX = useDerivedValue(() => {
+    'worklet';
+    if (!enableStacking || numberOfToasts <= 1 || isExpanded) {
+      return withTiming(1, {
+        duration: STACKING_ANIMATION_DURATION,
+        easing: easeOutQuartFn,
+      });
+    }
+
+    const multiplier =
+      toastPosition === 'top-center' ? index : numberOfToasts - index - 1;
+    const narrowAmount = stackGap * multiplier * 2;
+    const scale = Math.max(0.8, 1 - narrowAmount / screenWidth);
+    return withTiming(scale, {
+      duration: STACKING_ANIMATION_DURATION,
+      easing: easeOutQuartFn,
+    });
+  }, [
+    enableStacking,
+    numberOfToasts,
+    index,
+    toastPosition,
+    isExpanded,
+    stackGap,
+    screenWidth,
+  ]);
+
+  const absolutePositionStyle = useAnimatedStyle(() => {
+    const base: Record<string, unknown> = {
+      position: 'absolute',
+      width: '100%',
+      transform: [
+        { translateY: yPosition.value },
+        { scaleX: stackScaleX.value },
+      ],
+    };
+    if (toastPosition === 'bottom-center') {
+      base.bottom = 0;
+    } else {
+      base.top = 0;
+    }
+    return base;
+  }, [yPosition, toastPosition, stackScaleX]);
+
+  const wiggle = React.useCallback(() => {
+    'worklet';
+
+    wiggleSharedValue.value = withRepeat(
+      withTiming(Math.min(wiggleSharedValue.value * 1.035, 1.035), {
+        duration: 150,
+      }),
+      4,
+      true
+    );
+  }, [wiggleSharedValue]);
+
+  const wiggleHandler = React.useCallback(() => {
+    // we can't send Infinity over to the native layer.
+    if (duration === Infinity) {
+      return;
+    }
+
+    if (wiggleSharedValue.value !== 1) {
+      // we should animate back to 1 and then wiggle
+      wiggleSharedValue.value = withTiming(1, { duration: 150 }, wiggle);
+    } else {
+      wiggle();
+    }
+  }, [wiggle, wiggleSharedValue, duration]);
+
+  const stackZIndex =
+    toastPosition === 'top-center' ? -(index + 1) : -(numberOfToasts - index);
+
+  return {
+    absolutePositionStyle,
+    stackZIndex,
+    wiggleAnimationStyle,
+    wiggleHandler,
+  };
+};

--- a/src/use-toast-lifecycle.ts
+++ b/src/use-toast-lifecycle.ts
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import type { View } from 'react-native';
+import { useToastContext } from './context';
+import { toastStore } from './toast-store';
+import type { ToastProps } from './types';
+import { useAppStateListener } from './use-app-state';
+
+export type MeasurableToastRef = React.RefObject<
+  (View & { getBoundingClientRect?: () => DOMRect }) | null
+>;
+
+// Per-toast wiring that doesn't render anything: timer pause/resume on app
+// background/foreground, and reporting the measured height to the store.
+export const useToastLifecycle = ({
+  id,
+  toastRef,
+  variant,
+  title,
+  description,
+  jsx,
+}: {
+  id: ToastProps['id'];
+  toastRef: MeasurableToastRef;
+  variant: ToastProps['variant'];
+  title: string;
+  description?: string;
+  jsx?: React.ReactNode;
+}) => {
+  const { pauseWhenPageIsHidden } = useToastContext();
+
+  const onBackground = React.useCallback(() => {
+    if (!pauseWhenPageIsHidden) {
+      return;
+    }
+    toastStore.pauseTimer(id);
+  }, [pauseWhenPageIsHidden, id]);
+
+  const onForeground = React.useCallback(() => {
+    if (!pauseWhenPageIsHidden) {
+      return;
+    }
+    toastStore.resumeTimer(id);
+  }, [pauseWhenPageIsHidden, id]);
+
+  useAppStateListener({
+    onBackground,
+    onForeground,
+  });
+
+  // Synchronous layout read via getBoundingClientRect when available
+  // (refs are ReactNativeElement by default from RN 0.83). Older New Arch
+  // versions (e.g. RN 0.81/Expo SDK 54) don't expose it on refs, so fall
+  // back to async measureInWindow.
+  React.useLayoutEffect(() => {
+    if (!toastRef.current) {
+      return;
+    }
+    if (typeof toastRef.current.getBoundingClientRect === 'function') {
+      const { height } = toastRef.current.getBoundingClientRect();
+      toastStore.setToastHeight(id, height);
+      return;
+    }
+    let stale = false;
+    toastRef.current.measureInWindow((_x, _y, _w, height) => {
+      if (!stale) {
+        toastStore.setToastHeight(id, height);
+      }
+    });
+    return () => {
+      stale = true;
+    };
+    // Content-affecting fields are deps so the toast re-measures on change.
+  }, [toastRef, id, variant, title, description, jsx]);
+};

--- a/src/use-toast-swipe.ts
+++ b/src/use-toast-swipe.ts
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { useWindowDimensions } from 'react-native';
+import type { ViewStyle } from 'react-native';
+import { useDynamicToastContext, useToastContext } from './context';
+import { isPressNearCloseButton } from './press-utils';
+import { toastStore } from './toast-store';
+import type { ToastProps } from './types';
+import type { ToastSwipeHandler } from './gestures';
+
+// Swipe/press behavior for a single toast: timer pause/resume around drags,
+// expand/collapse and close-button handling on tap, and the memoized prop
+// object handed to ToastSwipeHandler.
+export const useToastSwipeProps = ({
+  id,
+  position,
+  numberOfToasts,
+  dismissible,
+  closeButton,
+  promiseOptions,
+  important,
+  unstyled,
+  mergedContainerStyle,
+  onDismiss,
+  onPress,
+}: {
+  id: ToastProps['id'];
+  position: ToastProps['position'];
+  numberOfToasts: number;
+  dismissible: boolean;
+  closeButton?: boolean;
+  promiseOptions?: ToastProps['promiseOptions'];
+  important?: boolean;
+  unstyled?: boolean;
+  mergedContainerStyle?: ViewStyle;
+  onDismiss?: ToastProps['onDismiss'];
+  onPress?: () => void;
+}): React.ComponentProps<typeof ToastSwipeHandler> => {
+  const {
+    position: positionCtx,
+    enableStacking,
+    toastOptions: { toastContainerStyle: toastContainerStyleCtx },
+  } = useToastContext();
+  const { isExpanded, toggleExpand } = useDynamicToastContext();
+  const { width: screenWidth } = useWindowDimensions();
+
+  const isDragging = React.useRef(false);
+
+  const onRemove = React.useCallback(() => {
+    onDismiss?.(id);
+  }, [onDismiss, id]);
+
+  const onSwipeBegin = React.useCallback(() => {
+    isDragging.current = true;
+    toastStore.pauseTimer(id);
+  }, [id]);
+
+  const onSwipeFinalize = React.useCallback(() => {
+    isDragging.current = false;
+    if (!isExpanded) {
+      toastStore.resumeTimer(id);
+    }
+  }, [id, isExpanded]);
+
+  const onSwipePress = React.useCallback(
+    ({ x }: { x: number; y: number }) => {
+      const pressToastPosition = position || positionCtx;
+      if (
+        enableStacking &&
+        numberOfToasts > 1 &&
+        pressToastPosition !== 'center'
+      ) {
+        if (
+          isPressNearCloseButton({
+            x,
+            viewWidth: screenWidth,
+          })
+        ) {
+          // On Android, the RNGH Tap gesture intercepts the touch before
+          // it reaches the native Pressable (close button). Dismiss
+          // explicitly when tapping the close button area while expanded.
+          if (isExpanded && closeButton && dismissible) {
+            onDismiss?.(id);
+          }
+        } else {
+          toggleExpand();
+        }
+      }
+      onPress?.();
+    },
+    [
+      position,
+      positionCtx,
+      enableStacking,
+      numberOfToasts,
+      toggleExpand,
+      onPress,
+      isExpanded,
+      closeButton,
+      dismissible,
+      onDismiss,
+      id,
+      screenWidth,
+    ]
+  );
+
+  return React.useMemo(
+    () => ({
+      onRemove,
+      onBegin: onSwipeBegin,
+      onFinalize: onSwipeFinalize,
+      onPress: onSwipePress,
+      enabled: !promiseOptions && dismissible,
+      style: [toastContainerStyleCtx, mergedContainerStyle],
+      unstyled,
+      important,
+      position,
+    }),
+    [
+      onRemove,
+      onSwipeBegin,
+      onSwipeFinalize,
+      onSwipePress,
+      promiseOptions,
+      dismissible,
+      toastContainerStyleCtx,
+      mergedContainerStyle,
+      unstyled,
+      important,
+      position,
+    ]
+  );
+};


### PR DESCRIPTION
Fixes #343

## Summary
Every store mutation (add, dismiss, expand, overlay toggle, height write) re-rendered **every** mounted toast: `ToasterUI` rebuilt `toastsForPosition`/`orderedToastIds` arrays on each render, so no memo boundary could hold. This PR:

- **Stable per-position render data**: `ToasterUI` derives `{ position, toasts, orderedToastIds }` per container through a memo table that reuses the previous entry (same array identities) when contents are unchanged (element-identity comparison via an exhaustive per-field comparator map; the store already preserves untouched toast objects). Entries are pruned when a position empties so dismissed toasts' props can't be retained.
- **`React.memo(Toast)`** with default shallow comparison — no custom comparator by design. `Toast` receives an explicit, narrow prop set (no `ToasterProps` rest-spread), so nothing object-valued can silently defeat the memo.
- **Positioner memos**: `getContainerStyle`/`getInsetValues` no longer reallocate per render; the outside-pressable area is computed only while expanded.

Result: a toast added/dismissed at one position no longer re-renders toasts at another. `dismissToast` only bumps the heights version when the toast actually had a height entry. Known residual (by design, tracked in #344): height writes — including removal of a measured toast's height on dismiss — flow through `DynamicToastContext` and still re-render all toasts.

Note: the memo table uses a `useState`-held Map rather than a ref — the repo's `react-hooks/refs` rule forbids ref reads during render; writes are render-idempotent.

Review fixes (`fce1d13`): dismiss height-version guard, explicit Toast prop set, positionsCache pruning, exhaustive PositionData comparator, `close`-as-string RN crash fix in `CloseButton`, gated outside-pressable computation, shared `resetToastStore()`/renderer-cleanup test helpers, prettier on touched files.

## Test evidence
TDD (red-green): `src/__tests__/toaster-perf.test.tsx` observes Toast renders by wrapping `useToastPosition` —
1. `orderedToastIds` identity is stable across unrelated store changes (was: fresh array every render — failed before the memo table)
2. adding a toast at `bottom-center` causes **zero** re-renders of a `top-center` toast (was: 1 — failed before `React.memo`)
3. dismissing a heightless toast at another position causes zero re-renders (was: version bump on every dismiss)
4. a host re-render of `<Toaster />` with unchanged props causes zero Toast re-renders (locks the explicit-prop memo contract)

- `pnpm test`: 165 passed (11 suites) — all pre-existing render/position/store tests unchanged
- `pnpm typecheck` / `pnpm lint`: clean

## Manual test plan (example app)
Run from this branch: `git checkout perf/memoize-toast && pnpm install && pnpm example start`, then `i` or `a`.

Behavior must be **identical to main** — this is a pure memoization change:
1. **Stacking**: settings → enableStacking ON, fire 4-5 toasts → stack renders, scaleX narrowing on back toasts, tap to expand, tap outside to collapse, swipe-dismiss front toast → reflow correct.
2. **Mixed positions**: fire toasts at default + `position: 'top-center'` (temp button: `toast('top', { position: 'top-center' })`) → both containers behave, no stale layouts.
3. **Update path**: fire `toast('a', { id: 'x' })` then `toast('b', { id: 'x' })` (temp button) → content updates in place (memo must not swallow updates; the store swaps the toast object so shallow compare catches it), wiggle-on-update still fires if enabled.
4. **Dynamic changes**: rotate device (width-dependent swipe/stack math), toggle theme in settings, expand/collapse repeatedly → no frozen/stale toasts.
5. **Custom close**: temp button `toast('hi', { close: 'Dismiss' })` → renders the text instead of crashing ("Text strings must be rendered within a <Text> component"); a JSX `close` element still renders as-is.
6. **Toaster-level styling**: pass `style`/`styles`/`unstyled` on `<Toaster />` → toasts still pick them up (props now passed explicitly instead of rest-spread).
7. **Expand/collapse tap area**: with stacking on, expand a stack → tapping outside still collapses it (outside-pressable now computed only while expanded).
8. **Perf smoke (optional)**: with React DevTools profiler on the example app, add a bottom-center toast while top-center toasts are visible → top-center Toast components show no commit.

Revert any temp buttons when done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
